### PR TITLE
feat/retain-base-selection 

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -156,8 +156,9 @@ State is owned at the appropriate level:
 | Current screen (`setup` / `game` / `help`) | `App` | Passed as callback props (`onStartGame`, `onBack`, `onHelp`) |
 | Previous screen (for help back-navigation) | `App` | Stored so the help screen knows where to return |
 | Selected base | `App` | Set on `onStartGame`, passed into `SwuGameScreen` |
+| Last setup selection (`set`, `aspect`, `key`) | `App` | Saved on `handleConfirm`; passed as `initialSelection` prop to `SwuSetupScreen` so dropdowns are pre-populated on back navigation |
 | Hyperspace preference | `App` / localStorage | Read at startup, toggled on setup screen, passed to game screen |
-| Filter state (set, aspect, card) | `useSwuSetup` | Local to setup screen |
+| Filter state (set, aspect, card) | `useSwuSetup` | Seeded from `initialSelection` on mount; local after that |
 | Damage counter | `useSwuGame` | Local to game screen |
 | Image load/error state | `useSwuGame` | Local to game screen |
 
@@ -166,8 +167,15 @@ State is owned at the appropriate level:
 1. User selects set, aspect, and base in setup screen dropdowns
 2. `useSwuSetup` manages the filter state and auto-selects when only one option remains
 3. User clicks `>` — `handleSubmit` in `useSwuSetup` calls `onStartGame(selectedBase, effectiveHyperspace)`
-4. `App` sets `screen = 'game'`, `selectedBase`, and `useHyperspace`
+4. `App` sets `screen = 'game'`, `selectedBase`, `useHyperspace`, and `lastSelection`
 5. `SwuGameScreen` receives `base` and `useHyperspace`, initialises `useSwuGame` with the correct image URL list
+
+### Example flow: Game → Back → Setup (retaining selection)
+
+1. User clicks `<` in the game screen — `handleBack` sets `screen = 'setup'`
+2. `SwuSetupScreen` re-mounts with `initialSelection` prop set to the `lastSelection` saved in step 4 above
+3. `useSwuSetup` seeds `selectedSet`, `selectedAspect`, and `selectedKey` from `initialSelection` via `useState` initialisers
+4. Dropdowns are immediately pre-populated; the submit button is active; user can start again without re-selecting
 
 ### Example flow: Damage tracking
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import SwuSetupScreen from './components/swuSetupScreen'
 import SwuGameScreen from './components/swuGameScreen'
 import SwuHelpScreen from './components/swuHelpScreen'
 import { Base } from './hooks/useBases'
+import { InitialSelection } from './hooks/useSwuSetup'
 
 type Screen = 'setup' | 'game' | 'help'
 
@@ -11,17 +12,17 @@ function App() {
   const [previousScreen, setPreviousScreen] = useState<Screen>('setup')
   const [selectedBase, setSelectedBase] = useState<Base | null>(null)
   const [useHyperspace, setUseHyperspace] = useState(false)
+  const [lastSelection, setLastSelection] = useState<InitialSelection | null>(null)
 
   const handleConfirm = (base: Base, hyperspace: boolean) => {
     setSelectedBase(base)
     setUseHyperspace(hyperspace)
+    setLastSelection({ set: base.set, aspect: base.aspects[0] ?? 'None', key: `${base.set}-${base.number}` })
     setScreen('game')
   }
 
   const handleBack = () => {
     setScreen('setup')
-    setSelectedBase(null)
-    setUseHyperspace(false)
   }
 
   const handleHelp = () => {
@@ -38,7 +39,7 @@ function App() {
   }
 
   if (screen === 'setup') {
-    return <SwuSetupScreen onConfirm={handleConfirm} onHelp={handleHelp} />
+    return <SwuSetupScreen onConfirm={handleConfirm} onHelp={handleHelp} initialSelection={lastSelection} />
   }
 
   return <SwuGameScreen base={selectedBase!} onBack={handleBack} onHelp={handleHelp} useHyperspace={useHyperspace} />

--- a/src/components/swuSetupScreen.tsx
+++ b/src/components/swuSetupScreen.tsx
@@ -1,14 +1,15 @@
 import { Base } from '../hooks/useBases'
-import { useSwuSetup } from '../hooks/useSwuSetup'
+import { useSwuSetup, InitialSelection } from '../hooks/useSwuSetup'
 import SwuSetupScreenView from './swuSetupScreenView'
 
 interface Props {
   onConfirm: (base: Base, useHyperspace: boolean) => void
   onHelp: () => void
+  initialSelection?: InitialSelection | null
 }
 
-function SwuSetupScreen({ onConfirm, onHelp }: Props) {
-  const setup = useSwuSetup(onConfirm)
+function SwuSetupScreen({ onConfirm, onHelp, initialSelection }: Props) {
+  const setup = useSwuSetup(onConfirm, initialSelection)
 
   return (
     <SwuSetupScreenView

--- a/src/hooks/useSwuSetup.ts
+++ b/src/hooks/useSwuSetup.ts
@@ -1,15 +1,24 @@
 import { useState, useMemo, useEffect } from 'react'
 import { useBases, Base } from './useBases'
 
-const ASPECT_ORDER = ['Aggression', 'Command', 'Cunning', 'Vigilance', 'None']
+const ASPECT_ORDER = ['Vigilance', 'Command', 'Aggression', 'Cunning', 'None']
 const HYPERSPACE_PREF_KEY = 'pref_hyperspace'
 
-export function useSwuSetup(onConfirm: (base: Base, useHyperspace: boolean) => void) {
+export interface InitialSelection {
+  set: string
+  aspect: string
+  key: string
+}
+
+export function useSwuSetup(
+  onConfirm: (base: Base, useHyperspace: boolean) => void,
+  initialSelection?: InitialSelection | null,
+) {
   const { bases, loading, error } = useBases()
 
-  const [selectedSet, setSelectedSet] = useState('')
-  const [selectedAspect, setSelectedAspect] = useState('')
-  const [selectedKey, setSelectedKey] = useState('')
+  const [selectedSet, setSelectedSet] = useState(initialSelection?.set ?? '')
+  const [selectedAspect, setSelectedAspect] = useState(initialSelection?.aspect ?? '')
+  const [selectedKey, setSelectedKey] = useState(initialSelection?.key ?? '')
   const [useHyperspace, setUseHyperspace] = useState<boolean>(() => {
     return localStorage.getItem(HYPERSPACE_PREF_KEY) === 'true'
   })

--- a/src/test/App.test.tsx
+++ b/src/test/App.test.tsx
@@ -141,6 +141,69 @@ describe('App', () => {
     expect(screen.getByText('Select Base')).toBeInTheDocument()
   })
 
+  // --- Back navigation retains selection ---
+
+  it('Retains selected set after navigating back from game screen', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+    await waitFor(() => expect(screen.getAllByRole('combobox')).toHaveLength(3))
+    await user.selectOptions(screen.getAllByRole('combobox')[0], 'SOR')
+    await user.selectOptions(screen.getAllByRole('combobox')[1], 'Aggression')
+    await user.selectOptions(screen.getAllByRole('combobox')[2], 'SOR-026')
+    await user.click(screen.getByText('>'))
+    await user.click(screen.getByText('<'))
+    expect((screen.getAllByRole('combobox')[0] as HTMLSelectElement).value).toBe('SOR')
+  })
+
+  it('Retains selected aspect after navigating back from game screen', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+    await waitFor(() => expect(screen.getAllByRole('combobox')).toHaveLength(3))
+    await user.selectOptions(screen.getAllByRole('combobox')[0], 'SOR')
+    await user.selectOptions(screen.getAllByRole('combobox')[1], 'Aggression')
+    await user.selectOptions(screen.getAllByRole('combobox')[2], 'SOR-026')
+    await user.click(screen.getByText('>'))
+    await user.click(screen.getByText('<'))
+    expect((screen.getAllByRole('combobox')[1] as HTMLSelectElement).value).toBe('Aggression')
+  })
+
+  it('Retains selected base after navigating back from game screen', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+    await waitFor(() => expect(screen.getAllByRole('combobox')).toHaveLength(3))
+    await user.selectOptions(screen.getAllByRole('combobox')[0], 'SOR')
+    await user.selectOptions(screen.getAllByRole('combobox')[1], 'Aggression')
+    await user.selectOptions(screen.getAllByRole('combobox')[2], 'SOR-026')
+    await user.click(screen.getByText('>'))
+    await user.click(screen.getByText('<'))
+    expect((screen.getAllByRole('combobox')[2] as HTMLSelectElement).value).toBe('SOR-026')
+  })
+
+  it('Submit button is immediately active after navigating back', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+    await waitFor(() => expect(screen.getAllByRole('combobox')).toHaveLength(3))
+    await user.selectOptions(screen.getAllByRole('combobox')[0], 'SOR')
+    await user.selectOptions(screen.getAllByRole('combobox')[1], 'Aggression')
+    await user.selectOptions(screen.getAllByRole('combobox')[2], 'SOR-026')
+    await user.click(screen.getByText('>'))
+    await user.click(screen.getByText('<'))
+    expect(screen.getByText('>')).not.toBeDisabled()
+  })
+
+  it('Can start a new game immediately after navigating back without re-selecting', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+    await waitFor(() => expect(screen.getAllByRole('combobox')).toHaveLength(3))
+    await user.selectOptions(screen.getAllByRole('combobox')[0], 'SOR')
+    await user.selectOptions(screen.getAllByRole('combobox')[1], 'Aggression')
+    await user.selectOptions(screen.getAllByRole('combobox')[2], 'SOR-026')
+    await user.click(screen.getByText('>'))
+    await user.click(screen.getByText('<'))
+    await user.click(screen.getByText('>'))
+    expect(screen.getByText('Remaining: 30')).toBeInTheDocument()
+  })
+
   // --- Help navigation ---
 
   it('Help button is visible on setup screen', async () => {

--- a/src/test/useSwuSetup.test.ts
+++ b/src/test/useSwuSetup.test.ts
@@ -385,4 +385,43 @@ describe('useSwuSetup', () => {
     expect(onConfirm).toHaveBeenCalledWith(baseA, false)
   })
 
+  // --- initialSelection ---
+
+  it('Pre-populates selectedSet from initialSelection', () => {
+    const { result } = renderHook(() =>
+      useSwuSetup(vi.fn(), { set: 'SOR', aspect: 'Aggression', key: 'SOR-026' })
+    )
+    expect(result.current.selectedSet).toBe('SOR')
+  })
+
+  it('Pre-populates selectedAspect from initialSelection', () => {
+    const { result } = renderHook(() =>
+      useSwuSetup(vi.fn(), { set: 'SOR', aspect: 'Aggression', key: 'SOR-026' })
+    )
+    expect(result.current.selectedAspect).toBe('Aggression')
+  })
+
+  it('Pre-populates selectedKey from initialSelection', () => {
+    const { result } = renderHook(() =>
+      useSwuSetup(vi.fn(), { set: 'SOR', aspect: 'Aggression', key: 'SOR-026' })
+    )
+    expect(result.current.selectedKey).toBe('SOR-026')
+  })
+
+  it('Resolves selectedBase from initialSelection once bases are loaded', () => {
+    const { result } = renderHook(() =>
+      useSwuSetup(vi.fn(), { set: 'SOR', aspect: 'Aggression', key: 'SOR-026' })
+    )
+    expect(result.current.selectedBase).toEqual(baseA)
+  })
+
+  it('Submit button is immediately active when initialSelection matches a loaded base', () => {
+    const onConfirm = vi.fn()
+    const { result } = renderHook(() =>
+      useSwuSetup(onConfirm, { set: 'SOR', aspect: 'Aggression', key: 'SOR-026' })
+    )
+    act(() => result.current.handleSubmit())
+    expect(onConfirm).toHaveBeenCalledWith(baseA, false)
+  })
+
 })


### PR DESCRIPTION
Adds memory of last base selected to allow return to set up screen from game screen to see the base originally selected

Closes #45 