### PR TITLE
refactor/shared-art-component 

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,11 +59,13 @@ The app is served at `/dmgCtrl/` and is designed to be added to an iOS home scre
 ```
 App
 ├── SwuSetupScreen        (container)
-│   ├── useSwuSetup       (hook — all setup logic)
+│   ├── useSwuSetup       (hook — filtering, auto-select, hyperspace preference)
+│   ├── useBaseArt        (hook — ordered art fallback chain, image load state)
 │   └── SwuSetupScreenView (view — renders selects, image preview, start button)
-│       └── ImagePreview  (component — setup screen art display)
+│       └── ImagePreview  (pure view — renders art or error message from props)
 ├── SwuGameScreen         (container)
-│   ├── useSwuGame        (hook — counter and image fallback logic)
+│   ├── useSwuGame        (hook — damage counter)
+│   ├── useBaseArt        (hook — ordered art fallback chain, image load state)
 │   └── SwuGameScreenView (view — renders counter, image, epic action)
 └── SwuHelpScreen         (standalone screen — renders help.md content)
 
@@ -102,7 +104,7 @@ src/
   components/
     layout/
       AppScreenLayout.tsx  Shared full-screen layout wrapper (background, safe area)
-    imagePreview.tsx        Setup screen card art preview with hyperspace toggle
+    imagePreview.tsx        Pure view — renders card art or error message from props
     swuGameScreen.tsx       Game screen container
     swuGameScreenView.tsx   Game screen view
     swuHelpScreen.tsx       Help screen (renders help.md)
@@ -110,10 +112,11 @@ src/
     swuSetupScreenView.tsx  Setup screen view
 
   hooks/
+    useBaseArt.ts           Ordered art fallback chain shared by setup and game screens
     useBases.ts             Fetches and caches the full list of Base cards
     useOrientation.ts       Detects portrait vs landscape via resize event
-    useSwuGame.ts           Game screen logic — counter and image fallback chain
-    useSwuSetup.ts          Setup screen logic — filtering, auto-select, preferences
+    useSwuGame.ts           Damage counter
+    useSwuSetup.ts          Setup screen logic — filtering, auto-select, hyperspace preference
 
   test/
     setup.ts                Vitest setup (jest-dom matchers)
@@ -122,9 +125,10 @@ src/
     swuGameScreen.test.tsx  Game screen container tests
     swuHelpScreen.test.tsx  Help screen tests
     swuSetupScreen.test.tsx Setup screen container tests
+    useBaseArt.test.ts      Art fallback chain hook tests
     useBases.test.ts        Data layer hook tests
     useOrientation.test.ts  Orientation hook tests
-    useSwuGame.test.ts      Game logic hook tests
+    useSwuGame.test.ts      Counter hook tests
     useSwuSetup.test.ts     Setup logic hook tests
 
   assets/
@@ -160,22 +164,15 @@ State is owned at the appropriate level:
 | Hyperspace preference | `App` / localStorage | Read at startup, toggled on setup screen, passed to game screen |
 | Filter state (set, aspect, card) | `useSwuSetup` | Seeded from `initialSelection` on mount; local after that |
 | Damage counter | `useSwuGame` | Local to game screen |
-| Image load/error state | `useSwuGame` | Local to game screen |
+| Art fallback index, image load state | `useBaseArt` | Local to whichever screen called it; reset when base changes |
 
 ### Example flow: Setup → Game
 
 1. User selects set, aspect, and base in setup screen dropdowns
 2. `useSwuSetup` manages the filter state and auto-selects when only one option remains
 3. User clicks `>` — `handleSubmit` in `useSwuSetup` calls `onStartGame(selectedBase, effectiveHyperspace)`
-4. `App` sets `screen = 'game'`, `selectedBase`, `useHyperspace`, and `lastSelection`
-5. `SwuGameScreen` receives `base` and `useHyperspace`, initialises `useSwuGame` with the correct image URL list
-
-### Example flow: Game → Back → Setup (retaining selection)
-
-1. User clicks `<` in the game screen — `handleBack` sets `screen = 'setup'`
-2. `SwuSetupScreen` re-mounts with `initialSelection` prop set to the `lastSelection` saved in step 4 above
-3. `useSwuSetup` seeds `selectedSet`, `selectedAspect`, and `selectedKey` from `initialSelection` via `useState` initialisers
-4. Dropdowns are immediately pre-populated; the submit button is active; user can start again without re-selecting
+4. `App` sets `screen = 'game'`, `selectedBase`, and `useHyperspace`
+5. `SwuGameScreen` receives `base` and `useHyperspace`, `useBaseArt` builds the ordered fallback chain and manages image state
 
 ### Example flow: Damage tracking
 
@@ -240,30 +237,23 @@ Card art is served from two CDNs with different characteristics:
 
 The `Base` interface captures all four possible art sources: `frontArt`, `frontArtLowRes`, `hyperspaceArtHiRes`, `hyperspaceArt`. Any field may be `null` depending on the set's data availability.
 
-#### Game screen fallback chain
+#### Art fallback chain (`useBaseArt`)
 
-`SwuGameScreen` builds an ordered `imageSrcs` array (filtering out `null` entries) and passes it to `useSwuGame`. On each `onError` the hook advances to the next URL; `imageError` only becomes `true` once all are exhausted.
+Both the setup screen and the game screen call `useBaseArt(base, useHyperspace)`, which builds an ordered URL list (filtering out `null` entries) and maintains a fallback index. On each `onError` the index advances; `allFailed` only becomes `true` once all URLs are exhausted. The hook also tracks `imageLoaded`, `normalFailed`, and `hyperspaceFailed` so callers can derive UI state without re-inspecting the base object.
 
 **Hyperspace preferred** (`useHyperspace = true`):
 ```
-hyperspaceArtHiRes → hyperspaceArt → frontArt → frontArtLowRes → text
+hyperspaceArtHiRes → hyperspaceArt → frontArt → frontArtLowRes → text/error
 ```
 
 **Normal preferred** (`useHyperspace = false`):
 ```
-frontArt → frontArtLowRes → hyperspaceArtHiRes → hyperspaceArt → text
+frontArt → frontArtLowRes → hyperspaceArtHiRes → hyperspaceArt → text/error
 ```
 
-The normal-preferred chain always falls back to hyperspace art rather than showing no image — a base image is always better than a text fallback.
+The normal-preferred chain always falls back to hyperspace art before giving up — a base image is always better than a text fallback.
 
-#### Setup screen art (ImagePreview)
-
-`imagePreview.tsx` derives effective src values at render time:
-
-- **Normal:** `base.frontArt ?? base.frontArtLowRes`
-- **Hyperspace:** `base.hyperspaceArtHiRes ?? base.hyperspaceArt`
-
-This ensures the highest-quality available URL is shown in each mode without an explicit fallback chain.
+The setup screen uses `normalFailed` and `hyperspaceFailed` to show contextual messages ("Only hyperspace image available", "Hyperspace variant not found") and to hide the hyperspace toggle when either tier has been exhausted. The game screen uses `allFailed` to switch to the text fallback (base name, subtitle, epic action).
 
 ### Caching
 
@@ -325,9 +315,9 @@ The game screen is designed for **landscape orientation**. `useOrientation` dete
 
 ### Game screen
 
-1. Container builds `imageSrcs` array based on `useHyperspace` flag and available art fields
-2. `useSwuGame(imageSrcs)` manages counter state and image fallback
-3. `currentImageSrc` is passed as a prop to the view (not recomputed in the view)
+1. `useBaseArt(base, useHyperspace)` manages the ordered fallback chain and image load state
+2. `useSwuGame()` manages the damage counter
+3. `art.src`, `art.imageLoaded`, `art.allFailed`, `art.onLoad`, `art.onError` are passed as props to the view
 4. View renders the counter, card image, and epic action text
 
 ### Adding a new feature
@@ -448,12 +438,12 @@ The app targets mobile browsers and PWA installation. Key performance constraint
 ### Avoiding unnecessary re-renders
 
 - State is co-located with the component that needs it — no prop drilling through many layers
-- Derived values (e.g. `filteredBases`, `imageSrcs`) are computed inline in the container; `useMemo` can be added if profiling reveals a bottleneck
+- Derived values (e.g. `filteredBases`) are computed in hooks with `useMemo`; `useBaseArt` entries are memoised so the array only rebuilds when `base` or `useHyperspace` changes
 
 ### Image loading
 
 - Card art is lazy-loaded via the browser's default `<img>` behaviour
-- The fallback chain in `useSwuGame` means a broken image never leaves a blank gap — it advances to the next URL or shows text
+- The fallback chain in `useBaseArt` means a broken image never leaves a blank gap — it advances to the next URL or shows text
 - The setup screen image preview is displayed before game start, giving the browser time to cache the URL before the game screen renders it
 
 ---
@@ -492,7 +482,7 @@ The app targets mobile browsers and PWA installation. Key performance constraint
 | **hyperspaceArt** | The reliable low-res hyperspace image URL from swuapi.com (`cdn.starwarsunlimited.com`, 400×286). `null` for SOR/SHD/TWI (no longer in swuapi.com). |
 | **hyperspaceArtHiRes** | A constructed hi-res hyperspace image URL from swu-db.com (`cdn.swu-db.com`, 1560×1120). Derived from card number for active sets, or from the static +266 offset map for SOR/SHD/TWI. May 403 for a small number of unindexed cards. |
 | **Static hyperspace map** | A hardcoded mapping of SOR, SHD, and TWI base card numbers to their hyperspace card numbers (offset +266). Used because those sets no longer appear in swuapi.com. |
-| **Fallback chain** | The ordered list of image URLs tried by `useSwuGame`. Hyperspace preferred: `[hyperspaceArtHiRes, hyperspaceArt, frontArt, frontArtLowRes]`. Normal preferred: `[frontArt, frontArtLowRes, hyperspaceArtHiRes, hyperspaceArt]`. The next URL is tried on `onError`; text fallback shown only when all are exhausted. |
+| **Fallback chain** | The ordered list of image URLs managed by `useBaseArt`. Hyperspace preferred: `[hyperspaceArtHiRes, hyperspaceArt, frontArt, frontArtLowRes]`. Normal preferred: `[frontArt, frontArtLowRes, hyperspaceArtHiRes, hyperspaceArt]`. The next URL is tried on `onError`; text fallback shown only when all are exhausted. |
 | **Container** | A React component that owns logic — calls hooks, computes derived state, and passes everything to a View component as props. |
 | **View** | A React component that only renders — receives all data and callbacks as props, contains no business logic. |
 | **AppScreenLayout** | The shared full-screen layout wrapper that provides background, safe area padding, and star field for every screen. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,11 +59,13 @@ The app is served at `/dmgCtrl/` and is designed to be added to an iOS home scre
 ```
 App
 ├── SwuSetupScreen        (container)
-│   ├── useSwuSetup       (hook — all setup logic)
+│   ├── useSwuSetup       (hook — filtering, auto-select, hyperspace preference)
+│   ├── useBaseArt        (hook — ordered art fallback chain, image load state)
 │   └── SwuSetupScreenView (view — renders selects, image preview, start button)
-│       └── ImagePreview  (component — setup screen art display)
+│       └── ImagePreview  (pure view — renders art or error message from props)
 ├── SwuGameScreen         (container)
-│   ├── useSwuGame        (hook — counter and image fallback logic)
+│   ├── useSwuGame        (hook — damage counter)
+│   ├── useBaseArt        (hook — ordered art fallback chain, image load state)
 │   └── SwuGameScreenView (view — renders counter, image, epic action)
 └── SwuHelpScreen         (standalone screen — renders help.md content)
 
@@ -102,7 +104,7 @@ src/
   components/
     layout/
       AppScreenLayout.tsx  Shared full-screen layout wrapper (background, safe area)
-    imagePreview.tsx        Setup screen card art preview with hyperspace toggle
+    imagePreview.tsx        Pure view — renders card art or error message from props
     swuGameScreen.tsx       Game screen container
     swuGameScreenView.tsx   Game screen view
     swuHelpScreen.tsx       Help screen (renders help.md)
@@ -110,10 +112,11 @@ src/
     swuSetupScreenView.tsx  Setup screen view
 
   hooks/
+    useBaseArt.ts           Ordered art fallback chain shared by setup and game screens
     useBases.ts             Fetches and caches the full list of Base cards
     useOrientation.ts       Detects portrait vs landscape via resize event
-    useSwuGame.ts           Game screen logic — counter and image fallback chain
-    useSwuSetup.ts          Setup screen logic — filtering, auto-select, preferences
+    useSwuGame.ts           Damage counter
+    useSwuSetup.ts          Setup screen logic — filtering, auto-select, hyperspace preference
 
   test/
     setup.ts                Vitest setup (jest-dom matchers)
@@ -122,9 +125,10 @@ src/
     swuGameScreen.test.tsx  Game screen container tests
     swuHelpScreen.test.tsx  Help screen tests
     swuSetupScreen.test.tsx Setup screen container tests
+    useBaseArt.test.ts      Art fallback chain hook tests
     useBases.test.ts        Data layer hook tests
     useOrientation.test.ts  Orientation hook tests
-    useSwuGame.test.ts      Game logic hook tests
+    useSwuGame.test.ts      Counter hook tests
     useSwuSetup.test.ts     Setup logic hook tests
 
   assets/
@@ -159,7 +163,7 @@ State is owned at the appropriate level:
 | Hyperspace preference | `App` / localStorage | Read at startup, toggled on setup screen, passed to game screen |
 | Filter state (set, aspect, card) | `useSwuSetup` | Local to setup screen |
 | Damage counter | `useSwuGame` | Local to game screen |
-| Image load/error state | `useSwuGame` | Local to game screen |
+| Art fallback index, image load state | `useBaseArt` | Local to whichever screen called it; reset when base changes |
 
 ### Example flow: Setup → Game
 
@@ -167,7 +171,7 @@ State is owned at the appropriate level:
 2. `useSwuSetup` manages the filter state and auto-selects when only one option remains
 3. User clicks `>` — `handleSubmit` in `useSwuSetup` calls `onStartGame(selectedBase, effectiveHyperspace)`
 4. `App` sets `screen = 'game'`, `selectedBase`, and `useHyperspace`
-5. `SwuGameScreen` receives `base` and `useHyperspace`, initialises `useSwuGame` with the correct image URL list
+5. `SwuGameScreen` receives `base` and `useHyperspace`, `useBaseArt` builds the ordered fallback chain and manages image state
 
 ### Example flow: Damage tracking
 
@@ -232,30 +236,23 @@ Card art is served from two CDNs with different characteristics:
 
 The `Base` interface captures all four possible art sources: `frontArt`, `frontArtLowRes`, `hyperspaceArtHiRes`, `hyperspaceArt`. Any field may be `null` depending on the set's data availability.
 
-#### Game screen fallback chain
+#### Art fallback chain (`useBaseArt`)
 
-`SwuGameScreen` builds an ordered `imageSrcs` array (filtering out `null` entries) and passes it to `useSwuGame`. On each `onError` the hook advances to the next URL; `imageError` only becomes `true` once all are exhausted.
+Both the setup screen and the game screen call `useBaseArt(base, useHyperspace)`, which builds an ordered URL list (filtering out `null` entries) and maintains a fallback index. On each `onError` the index advances; `allFailed` only becomes `true` once all URLs are exhausted. The hook also tracks `imageLoaded`, `normalFailed`, and `hyperspaceFailed` so callers can derive UI state without re-inspecting the base object.
 
 **Hyperspace preferred** (`useHyperspace = true`):
 ```
-hyperspaceArtHiRes → hyperspaceArt → frontArt → frontArtLowRes → text
+hyperspaceArtHiRes → hyperspaceArt → frontArt → frontArtLowRes → text/error
 ```
 
 **Normal preferred** (`useHyperspace = false`):
 ```
-frontArt → frontArtLowRes → hyperspaceArtHiRes → hyperspaceArt → text
+frontArt → frontArtLowRes → hyperspaceArtHiRes → hyperspaceArt → text/error
 ```
 
-The normal-preferred chain always falls back to hyperspace art rather than showing no image — a base image is always better than a text fallback.
+The normal-preferred chain always falls back to hyperspace art before giving up — a base image is always better than a text fallback.
 
-#### Setup screen art (ImagePreview)
-
-`imagePreview.tsx` derives effective src values at render time:
-
-- **Normal:** `base.frontArt ?? base.frontArtLowRes`
-- **Hyperspace:** `base.hyperspaceArtHiRes ?? base.hyperspaceArt`
-
-This ensures the highest-quality available URL is shown in each mode without an explicit fallback chain.
+The setup screen uses `normalFailed` and `hyperspaceFailed` to show contextual messages ("Only hyperspace image available", "Hyperspace variant not found") and to hide the hyperspace toggle when either tier has been exhausted. The game screen uses `allFailed` to switch to the text fallback (base name, subtitle, epic action).
 
 ### Caching
 
@@ -317,9 +314,9 @@ The game screen is designed for **landscape orientation**. `useOrientation` dete
 
 ### Game screen
 
-1. Container builds `imageSrcs` array based on `useHyperspace` flag and available art fields
-2. `useSwuGame(imageSrcs)` manages counter state and image fallback
-3. `currentImageSrc` is passed as a prop to the view (not recomputed in the view)
+1. `useBaseArt(base, useHyperspace)` manages the ordered fallback chain and image load state
+2. `useSwuGame()` manages the damage counter
+3. `art.src`, `art.imageLoaded`, `art.allFailed`, `art.onLoad`, `art.onError` are passed as props to the view
 4. View renders the counter, card image, and epic action text
 
 ### Adding a new feature
@@ -440,12 +437,12 @@ The app targets mobile browsers and PWA installation. Key performance constraint
 ### Avoiding unnecessary re-renders
 
 - State is co-located with the component that needs it — no prop drilling through many layers
-- Derived values (e.g. `filteredBases`, `imageSrcs`) are computed inline in the container; `useMemo` can be added if profiling reveals a bottleneck
+- Derived values (e.g. `filteredBases`) are computed in hooks with `useMemo`; `useBaseArt` entries are memoised so the array only rebuilds when `base` or `useHyperspace` changes
 
 ### Image loading
 
 - Card art is lazy-loaded via the browser's default `<img>` behaviour
-- The fallback chain in `useSwuGame` means a broken image never leaves a blank gap — it advances to the next URL or shows text
+- The fallback chain in `useBaseArt` means a broken image never leaves a blank gap — it advances to the next URL or shows text
 - The setup screen image preview is displayed before game start, giving the browser time to cache the URL before the game screen renders it
 
 ---
@@ -484,7 +481,7 @@ The app targets mobile browsers and PWA installation. Key performance constraint
 | **hyperspaceArt** | The reliable low-res hyperspace image URL from swuapi.com (`cdn.starwarsunlimited.com`, 400×286). `null` for SOR/SHD/TWI (no longer in swuapi.com). |
 | **hyperspaceArtHiRes** | A constructed hi-res hyperspace image URL from swu-db.com (`cdn.swu-db.com`, 1560×1120). Derived from card number for active sets, or from the static +266 offset map for SOR/SHD/TWI. May 403 for a small number of unindexed cards. |
 | **Static hyperspace map** | A hardcoded mapping of SOR, SHD, and TWI base card numbers to their hyperspace card numbers (offset +266). Used because those sets no longer appear in swuapi.com. |
-| **Fallback chain** | The ordered list of image URLs tried by `useSwuGame`. Hyperspace preferred: `[hyperspaceArtHiRes, hyperspaceArt, frontArt, frontArtLowRes]`. Normal preferred: `[frontArt, frontArtLowRes, hyperspaceArtHiRes, hyperspaceArt]`. The next URL is tried on `onError`; text fallback shown only when all are exhausted. |
+| **Fallback chain** | The ordered list of image URLs managed by `useBaseArt`. Hyperspace preferred: `[hyperspaceArtHiRes, hyperspaceArt, frontArt, frontArtLowRes]`. Normal preferred: `[frontArt, frontArtLowRes, hyperspaceArtHiRes, hyperspaceArt]`. The next URL is tried on `onError`; text fallback shown only when all are exhausted. |
 | **Container** | A React component that owns logic — calls hooks, computes derived state, and passes everything to a View component as props. |
 | **View** | A React component that only renders — receives all data and callbacks as props, contains no business logic. |
 | **AppScreenLayout** | The shared full-screen layout wrapper that provides background, safe area padding, and star field for every screen. |

--- a/src/components/imagePreview.tsx
+++ b/src/components/imagePreview.tsx
@@ -1,170 +1,54 @@
-import { useState, useEffect } from 'react'
 import { Base } from '../hooks/useBases'
 
 interface ImagePreviewProps {
   base: Base
+  src: string | null
+  isHyperspace: boolean
+  allFailed: boolean
   useHyperspace: boolean
-  onHyperspaceUnavailable: () => void
-  onNormalUnavailable: () => void
+  onError: () => void
 }
 
-function ImagePreview({
-  base,
-  useHyperspace,
-  onHyperspaceUnavailable,
-  onNormalUnavailable,
-}: ImagePreviewProps) {
-  const [normalHiResFailed, setNormalHiResFailed] = useState(false)
-  const [normalFailed, setNormalFailed] = useState(false)
-  const [hyperspaceFailed, setHyperspaceFailed] = useState(false)
+const imgStyle: React.CSSProperties = {
+  width: '100%',
+  borderRadius: '12px',
+  border: '2px solid #4fc3f7',
+  boxShadow: '0 0 20px rgba(79, 195, 247, 0.3)',
+}
 
-  // Reset failure state when base changes
-  useEffect(() => {
-    setNormalHiResFailed(false)
-    setNormalFailed(false)
-    setHyperspaceFailed(false)
-  }, [base.set, base.number])
+const messageStyle: React.CSSProperties = {
+  color: '#a8a8b3',
+  fontWeight: '300',
+  fontSize: 'clamp(0.7rem, 2.5vw, 1rem)',
+  margin: 0,
+  fontStyle: 'italic',
+}
 
-  const effectiveHyperspaceSrc = base.hyperspaceArtHiRes ?? base.hyperspaceArt
-  // Two-stage normal src: try hi-res CDN first, fall back to low-res within the
-  // same "normal" tier before declaring normal art unavailable.
-  const effectiveNormalSrc = (!normalHiResFailed && base.frontArt)
-    ? base.frontArt
-    : base.frontArtLowRes
+const errorStyle: React.CSSProperties = {
+  color: '#ff6b6b',
+  fontWeight: '300',
+  fontSize: 'clamp(0.7rem, 2.5vw, 1rem)',
+  margin: 0,
+  fontStyle: 'italic',
+}
 
-  const handleNormalError = () => {
-    if (!normalHiResFailed && base.frontArt && base.frontArtLowRes) {
-      // Hi-res CDN failed but low-res is available — try it silently
-      setNormalHiResFailed(true)
-    } else {
-      setNormalFailed(true)
-      onNormalUnavailable()
-    }
+function ImagePreview({ base, src, isHyperspace, allFailed, useHyperspace, onError }: ImagePreviewProps) {
+  if (allFailed || !src) {
+    return <p style={errorStyle}>No base images found</p>
   }
 
-  const showHyperspace = useHyperspace && !!effectiveHyperspaceSrc && !hyperspaceFailed
-  const showNormal = !showHyperspace && !normalFailed
+  const message = (!useHyperspace && isHyperspace)
+    ? 'Only hyperspace image available'
+    : (useHyperspace && !isHyperspace)
+      ? 'Hyperspace variant not found'
+      : null
 
-  if (normalFailed && hyperspaceFailed) {
-    return (
-      <p style={{
-        color: '#ff6b6b',
-        fontWeight: '300',
-        fontSize: 'clamp(0.7rem, 2.5vw, 1rem)',
-        margin: 0,
-        fontStyle: 'italic',
-      }}>
-        No base images found
-      </p>
-    )
-  }
-
-  if (normalFailed && !useHyperspace) {
-    // Normal failed, not trying hyperspace — check if hyperspace exists
-    if (effectiveHyperspaceSrc) {
-      return (
-        <>
-          <img
-            src={effectiveHyperspaceSrc}
-            alt={base.name}
-            onError={() => {
-              setHyperspaceFailed(true)
-            }}
-            style={{
-              width: '100%',
-              borderRadius: '12px',
-              border: '2px solid #4fc3f7',
-              boxShadow: '0 0 20px rgba(79, 195, 247, 0.3)',
-            }}
-          />
-          <p style={{
-            color: '#a8a8b3',
-            fontWeight: '300',
-            fontSize: 'clamp(0.7rem, 2.5vw, 1rem)',
-            margin: 0,
-            fontStyle: 'italic',
-          }}>
-            Only hyperspace image available
-          </p>
-        </>
-      )
-    }
-    return (
-      <p style={{
-        color: '#ff6b6b',
-        fontWeight: '300',
-        fontSize: 'clamp(0.7rem, 2.5vw, 1rem)',
-        margin: 0,
-        fontStyle: 'italic',
-      }}>
-        No base images found
-      </p>
-    )
-  }
-
-  if (showHyperspace) {
-    return (
-      <img
-        src={effectiveHyperspaceSrc!}
-        alt={base.name}
-        onError={() => {
-          setHyperspaceFailed(true)
-          onHyperspaceUnavailable()
-        }}
-        style={{
-          width: '100%',
-          borderRadius: '12px',
-          border: '2px solid #4fc3f7',
-          boxShadow: '0 0 20px rgba(79, 195, 247, 0.3)',
-        }}
-      />
-    )
-  }
-
-  if (hyperspaceFailed && useHyperspace) {
-    return (
-      <>
-        <img
-          src={effectiveNormalSrc!}
-          alt={base.name}
-          onError={handleNormalError}
-          style={{
-            width: '100%',
-            borderRadius: '12px',
-            border: '2px solid #4fc3f7',
-            boxShadow: '0 0 20px rgba(79, 195, 247, 0.3)',
-          }}
-        />
-        <p style={{
-          color: '#a8a8b3',
-          fontWeight: '300',
-          fontSize: 'clamp(0.7rem, 2.5vw, 1rem)',
-          margin: 0,
-          fontStyle: 'italic',
-        }}>
-          Hyperspace variant not found
-        </p>
-      </>
-    )
-  }
-
-  if (showNormal) {
-    return (
-      <img
-        src={effectiveNormalSrc!}
-        alt={base.name}
-        onError={handleNormalError}
-        style={{
-          width: '100%',
-          borderRadius: '12px',
-          border: '2px solid #4fc3f7',
-          boxShadow: '0 0 20px rgba(79, 195, 247, 0.3)',
-        }}
-      />
-    )
-  }
-
-  return null
+  return (
+    <>
+      <img src={src} alt={base.name} onError={onError} style={imgStyle} />
+      {message && <p style={messageStyle}>{message}</p>}
+    </>
+  )
 }
 
 export default ImagePreview

--- a/src/components/swuGameScreen.tsx
+++ b/src/components/swuGameScreen.tsx
@@ -1,5 +1,6 @@
 import { Base } from '../hooks/useBases'
 import { useSwuGame } from '../hooks/useSwuGame'
+import { useBaseArt } from '../hooks/useBaseArt'
 import { useOrientation } from '../hooks/useOrientation'
 import SwuGameScreenView from './swuGameScreenView'
 import AppScreenLayout from './layout/AppScreenLayout'
@@ -12,21 +13,8 @@ interface Props {
 }
 
 function SwuGameScreen({ base, onBack, onHelp, useHyperspace }: Props) {
-  const imageSrcs = useHyperspace
-    ? [
-        ...(base.hyperspaceArtHiRes ? [base.hyperspaceArtHiRes] : []),
-        ...(base.hyperspaceArt ? [base.hyperspaceArt] : []),
-        ...(base.frontArt ? [base.frontArt] : []),
-        ...(base.frontArtLowRes ? [base.frontArtLowRes] : []),
-      ]
-    : [
-        ...(base.frontArt ? [base.frontArt] : []),
-        ...(base.frontArtLowRes ? [base.frontArtLowRes] : []),
-        ...(base.hyperspaceArtHiRes ? [base.hyperspaceArtHiRes] : []),
-        ...(base.hyperspaceArt ? [base.hyperspaceArt] : []),
-      ]
-
-  const { count, imageLoaded, imageError, currentImageSrc, increment, decrement, handleImageLoad, handleImageError } = useSwuGame(imageSrcs)
+  const art = useBaseArt(base, useHyperspace)
+  const { count, increment, decrement } = useSwuGame()
   const { isPortrait } = useOrientation()
 
   if (isPortrait) {
@@ -89,14 +77,14 @@ function SwuGameScreen({ base, onBack, onHelp, useHyperspace }: Props) {
       base={base}
       onBack={onBack}
       onHelp={onHelp}
-      imageSrc={currentImageSrc}
+      imageSrc={art.src ?? ''}
       count={count}
-      imageLoaded={imageLoaded}
-      imageError={imageError}
+      imageLoaded={art.imageLoaded}
+      imageError={art.allFailed}
       onIncrement={increment}
       onDecrement={decrement}
-      onImageLoad={handleImageLoad}
-      onImageError={handleImageError}
+      onImageLoad={art.onLoad}
+      onImageError={art.onError}
     />
   )
 }

--- a/src/components/swuSetupScreen.tsx
+++ b/src/components/swuSetupScreen.tsx
@@ -1,15 +1,28 @@
 import { Base } from '../hooks/useBases'
 import { useSwuSetup, InitialSelection } from '../hooks/useSwuSetup'
+import { useBaseArt } from '../hooks/useBaseArt'
 import SwuSetupScreenView from './swuSetupScreenView'
 
 interface Props {
   onConfirm: (base: Base, useHyperspace: boolean) => void
   onHelp: () => void
   initialSelection?: InitialSelection | null
+  initialSelection?: InitialSelection | null
 }
 
 function SwuSetupScreen({ onConfirm, onHelp, initialSelection }: Props) {
   const setup = useSwuSetup(onConfirm, initialSelection)
+  const art = useBaseArt(setup.selectedBase, setup.useHyperspace)
+
+  const hasHyperspace = !!(
+    setup.selectedBase?.hyperspaceArtHiRes || setup.selectedBase?.hyperspaceArt
+  )
+  const showHyperspaceToggle = hasHyperspace && !art.normalFailed && !art.hyperspaceFailed
+
+  const handleSubmit = () => {
+    const effectiveHyperspace = setup.useHyperspace || art.normalFailed
+    setup.handleSubmit(effectiveHyperspace)
+  }
 
   return (
     <SwuSetupScreenView
@@ -23,15 +36,17 @@ function SwuSetupScreen({ onConfirm, onHelp, initialSelection }: Props) {
       selectedKey={setup.selectedKey}
       selectedBase={setup.selectedBase}
       useHyperspace={setup.useHyperspace}
-      showHyperspaceToggle={setup.showHyperspaceToggle}
+      showHyperspaceToggle={showHyperspaceToggle}
+      artSrc={art.src}
+      artIsHyperspace={art.isHyperspace}
+      artAllFailed={art.allFailed}
+      onArtError={art.onError}
       onSetChange={setup.handleSetChange}
       onAspectChange={setup.handleAspectChange}
       onKeyChange={setup.handleKeyChange}
       onHyperspaceToggle={setup.handleHyperspaceToggle}
-      onSubmit={setup.handleSubmit}
+      onSubmit={handleSubmit}
       onHelp={onHelp}
-      onNormalImageFailed={setup.handleNormalImageFailed}
-      onHyperspaceImageFailed={setup.handleHyperspaceImageFailed}
     />
   )
 }

--- a/src/components/swuSetupScreen.tsx
+++ b/src/components/swuSetupScreen.tsx
@@ -1,14 +1,27 @@
 import { Base } from '../hooks/useBases'
-import { useSwuSetup } from '../hooks/useSwuSetup'
+import { useSwuSetup, InitialSelection } from '../hooks/useSwuSetup'
+import { useBaseArt } from '../hooks/useBaseArt'
 import SwuSetupScreenView from './swuSetupScreenView'
 
 interface Props {
   onConfirm: (base: Base, useHyperspace: boolean) => void
   onHelp: () => void
+  initialSelection?: InitialSelection | null
 }
 
-function SwuSetupScreen({ onConfirm, onHelp }: Props) {
-  const setup = useSwuSetup(onConfirm)
+function SwuSetupScreen({ onConfirm, onHelp, initialSelection }: Props) {
+  const setup = useSwuSetup(onConfirm, initialSelection)
+  const art = useBaseArt(setup.selectedBase, setup.useHyperspace)
+
+  const hasHyperspace = !!(
+    setup.selectedBase?.hyperspaceArtHiRes || setup.selectedBase?.hyperspaceArt
+  )
+  const showHyperspaceToggle = hasHyperspace && !art.normalFailed && !art.hyperspaceFailed
+
+  const handleSubmit = () => {
+    const effectiveHyperspace = setup.useHyperspace || art.normalFailed
+    setup.handleSubmit(effectiveHyperspace)
+  }
 
   return (
     <SwuSetupScreenView
@@ -22,15 +35,17 @@ function SwuSetupScreen({ onConfirm, onHelp }: Props) {
       selectedKey={setup.selectedKey}
       selectedBase={setup.selectedBase}
       useHyperspace={setup.useHyperspace}
-      showHyperspaceToggle={setup.showHyperspaceToggle}
+      showHyperspaceToggle={showHyperspaceToggle}
+      artSrc={art.src}
+      artIsHyperspace={art.isHyperspace}
+      artAllFailed={art.allFailed}
+      onArtError={art.onError}
       onSetChange={setup.handleSetChange}
       onAspectChange={setup.handleAspectChange}
       onKeyChange={setup.handleKeyChange}
       onHyperspaceToggle={setup.handleHyperspaceToggle}
-      onSubmit={setup.handleSubmit}
+      onSubmit={handleSubmit}
       onHelp={onHelp}
-      onNormalImageFailed={setup.handleNormalImageFailed}
-      onHyperspaceImageFailed={setup.handleHyperspaceImageFailed}
     />
   )
 }

--- a/src/components/swuSetupScreenView.tsx
+++ b/src/components/swuSetupScreenView.tsx
@@ -14,14 +14,16 @@ interface Props {
   selectedBase: Base | null
   useHyperspace: boolean
   showHyperspaceToggle: boolean
+  artSrc: string | null
+  artIsHyperspace: boolean
+  artAllFailed: boolean
+  onArtError: () => void
   onSetChange: (set: string) => void
   onAspectChange: (aspect: string) => void
   onKeyChange: (key: string) => void
   onHyperspaceToggle: (value: boolean) => void
   onSubmit: () => void
   onHelp: () => void
-  onNormalImageFailed: () => void
-  onHyperspaceImageFailed: () => void
 }
 
 const selectStyle = (enabled: boolean, hasValue: boolean): React.CSSProperties => ({
@@ -54,14 +56,16 @@ function SwuSetupScreenView({
   selectedBase,
   useHyperspace,
   showHyperspaceToggle,
+  artSrc,
+  artIsHyperspace,
+  artAllFailed,
+  onArtError,
   onSetChange,
   onAspectChange,
   onKeyChange,
   onHyperspaceToggle,
   onSubmit,
   onHelp,
-  onNormalImageFailed,
-  onHyperspaceImageFailed,
 }: Props) {
   return (
     <AppScreenLayout>
@@ -283,9 +287,11 @@ function SwuSetupScreenView({
               }}>
                 <ImagePreview
                   base={selectedBase}
+                  src={artSrc}
+                  isHyperspace={artIsHyperspace}
+                  allFailed={artAllFailed}
                   useHyperspace={useHyperspace}
-                  onHyperspaceUnavailable={onHyperspaceImageFailed}
-                  onNormalUnavailable={onNormalImageFailed}
+                  onError={onArtError}
                 />
 
                 {/* Row 4: Hyperspace toggle */}

--- a/src/hooks/useBaseArt.ts
+++ b/src/hooks/useBaseArt.ts
@@ -1,0 +1,53 @@
+import { useState, useMemo, useEffect } from 'react'
+import { Base } from './useBases'
+
+interface ArtEntry {
+  url: string
+  isHyperspace: boolean
+}
+
+function buildEntries(base: Base, useHyperspace: boolean): ArtEntry[] {
+  const normal: ArtEntry[] = [
+    ...(base.frontArt ? [{ url: base.frontArt, isHyperspace: false }] : []),
+    ...(base.frontArtLowRes ? [{ url: base.frontArtLowRes, isHyperspace: false }] : []),
+  ]
+  const hyper: ArtEntry[] = [
+    ...(base.hyperspaceArtHiRes ? [{ url: base.hyperspaceArtHiRes, isHyperspace: true }] : []),
+    ...(base.hyperspaceArt ? [{ url: base.hyperspaceArt, isHyperspace: true }] : []),
+  ]
+  return useHyperspace ? [...hyper, ...normal] : [...normal, ...hyper]
+}
+
+export function useBaseArt(base: Base | null, useHyperspace: boolean) {
+  const [index, setIndex] = useState(0)
+  const [imageLoaded, setImageLoaded] = useState(false)
+
+  const entries = useMemo(
+    () => (base ? buildEntries(base, useHyperspace) : []),
+    [base, useHyperspace],
+  )
+
+  useEffect(() => {
+    setIndex(0)
+    setImageLoaded(false)
+  }, [base?.set, base?.number])
+
+  const current = entries[index] ?? null
+  const tried = entries.slice(0, index)
+  const normalCount = entries.filter(e => !e.isHyperspace).length
+  const hyperCount = entries.filter(e => e.isHyperspace).length
+
+  return {
+    src: current?.url ?? null,
+    isHyperspace: current?.isHyperspace ?? false,
+    allFailed: entries.length === 0 || index >= entries.length,
+    normalFailed: normalCount > 0 && tried.filter(e => !e.isHyperspace).length >= normalCount,
+    hyperspaceFailed: hyperCount > 0 && tried.filter(e => e.isHyperspace).length >= hyperCount,
+    imageLoaded,
+    onLoad: () => setImageLoaded(true),
+    onError: () => {
+      setImageLoaded(false)
+      setIndex(i => i + 1)
+    },
+  }
+}

--- a/src/hooks/useBases.ts
+++ b/src/hooks/useBases.ts
@@ -70,7 +70,7 @@ const STATIC_HYPERSPACE_SETS: Record<string, { number: string; name: string; hyp
     { number: '025', name: 'Shadow Collective Camp',  hyperspaceNumber: '300' },
     { number: '026', name: 'KCM Mining Facility',     hyperspaceNumber: '301' },
     { number: '027', name: 'The Nest',                hyperspaceNumber: '302' },
-    { number: '028', name: 'Petranaki Arena',         hyperspaceNumber: '517' },
+    { number: '028', name: 'Petranaki Arena',         hyperspaceNumber: '303' },
     { number: '029', name: 'Level 1313',              hyperspaceNumber: '518' },
     { number: '030', name: 'Pyke Palace',             hyperspaceNumber: '519' },
   ],

--- a/src/hooks/useSwuGame.ts
+++ b/src/hooks/useSwuGame.ts
@@ -1,24 +1,10 @@
 import { useState } from 'react'
 
-export function useSwuGame(imageSrcs: string[] = []) {
+export function useSwuGame() {
   const [count, setCount] = useState(0)
-  const [imageSrcIndex, setImageSrcIndex] = useState(0)
-  const [imageLoaded, setImageLoaded] = useState(false)
-  const [imageError, setImageError] = useState(false)
 
   const increment = () => setCount(c => c + 1)
   const decrement = () => setCount(c => Math.max(0, c - 1))
-  const handleImageLoad = () => setImageLoaded(true)
-  const handleImageError = () => {
-    if (imageSrcIndex < imageSrcs.length - 1) {
-      setImageSrcIndex(i => i + 1)
-      setImageLoaded(false)
-    } else {
-      setImageError(true)
-    }
-  }
 
-  const currentImageSrc = imageSrcs[imageSrcIndex] ?? ''
-
-  return { count, imageLoaded, imageError, currentImageSrc, increment, decrement, handleImageLoad, handleImageError }
+  return { count, increment, decrement }
 }

--- a/src/hooks/useSwuSetup.ts
+++ b/src/hooks/useSwuSetup.ts
@@ -1,20 +1,27 @@
 import { useState, useMemo, useEffect } from 'react'
 import { useBases, Base } from './useBases'
 
-const ASPECT_ORDER = ['Aggression', 'Command', 'Cunning', 'Vigilance', 'None']
+const ASPECT_ORDER = ['Vigilance', 'Command', 'Aggression', 'Cunning', 'None']
 const HYPERSPACE_PREF_KEY = 'pref_hyperspace'
 
-export function useSwuSetup(onConfirm: (base: Base, useHyperspace: boolean) => void) {
+export interface InitialSelection {
+  set: string
+  aspect: string
+  key: string
+}
+
+export function useSwuSetup(
+  onConfirm: (base: Base, useHyperspace: boolean) => void,
+  initialSelection?: InitialSelection | null,
+) {
   const { bases, loading, error } = useBases()
 
-  const [selectedSet, setSelectedSet] = useState('')
-  const [selectedAspect, setSelectedAspect] = useState('')
-  const [selectedKey, setSelectedKey] = useState('')
+  const [selectedSet, setSelectedSet] = useState(initialSelection?.set ?? '')
+  const [selectedAspect, setSelectedAspect] = useState(initialSelection?.aspect ?? '')
+  const [selectedKey, setSelectedKey] = useState(initialSelection?.key ?? '')
   const [useHyperspace, setUseHyperspace] = useState<boolean>(() => {
     return localStorage.getItem(HYPERSPACE_PREF_KEY) === 'true'
   })
-  const [normalImageFailed, setNormalImageFailed] = useState(false)
-  const [hyperspaceImageFailed, setHyperspaceImageFailed] = useState(false)
 
   const availableSets = useMemo(() => {
     return [...new Set(bases.map(b => b.set))].sort()
@@ -46,12 +53,6 @@ export function useSwuSetup(onConfirm: (base: Base, useHyperspace: boolean) => v
   const selectedBase = filteredBases.find(
     b => `${b.set}-${b.number}` === selectedKey
   ) ?? null
-
-  // Reset image failure state when base changes
-  useEffect(() => {
-    setNormalImageFailed(false)
-    setHyperspaceImageFailed(false)
-  }, [selectedKey])
 
   // Auto-select aspect when only one option available
   useEffect(() => {
@@ -88,21 +89,10 @@ export function useSwuSetup(onConfirm: (base: Base, useHyperspace: boolean) => v
     localStorage.setItem(HYPERSPACE_PREF_KEY, String(value))
   }
 
-  const handleSubmit = () => {
+  const handleSubmit = (effectiveHyperspace: boolean) => {
     if (!selectedBase) return
-    const hasHyperspace = !!(selectedBase.hyperspaceArtHiRes || selectedBase.hyperspaceArt)
-    const effectiveHyperspace = useHyperspace || (normalImageFailed && hasHyperspace)
     onConfirm(selectedBase, effectiveHyperspace)
   }
-
-  const handleNormalImageFailed = () => setNormalImageFailed(true)
-  const handleHyperspaceImageFailed = () => setHyperspaceImageFailed(true)
-
-  const showHyperspaceToggle = !!(
-    (selectedBase?.hyperspaceArtHiRes || selectedBase?.hyperspaceArt) &&
-    !hyperspaceImageFailed &&
-    !normalImageFailed
-  )
 
   return {
     loading,
@@ -115,15 +105,10 @@ export function useSwuSetup(onConfirm: (base: Base, useHyperspace: boolean) => v
     availableSets,
     availableAspects,
     filteredBases,
-    normalImageFailed,
-    hyperspaceImageFailed,
-    showHyperspaceToggle,
     handleSetChange,
     handleAspectChange,
     handleKeyChange,
     handleHyperspaceToggle,
     handleSubmit,
-    handleNormalImageFailed,
-    handleHyperspaceImageFailed,
   }
 }

--- a/src/hooks/useSwuSetup.ts
+++ b/src/hooks/useSwuSetup.ts
@@ -22,8 +22,6 @@ export function useSwuSetup(
   const [useHyperspace, setUseHyperspace] = useState<boolean>(() => {
     return localStorage.getItem(HYPERSPACE_PREF_KEY) === 'true'
   })
-  const [normalImageFailed, setNormalImageFailed] = useState(false)
-  const [hyperspaceImageFailed, setHyperspaceImageFailed] = useState(false)
 
   const availableSets = useMemo(() => {
     return [...new Set(bases.map(b => b.set))].sort()
@@ -55,12 +53,6 @@ export function useSwuSetup(
   const selectedBase = filteredBases.find(
     b => `${b.set}-${b.number}` === selectedKey
   ) ?? null
-
-  // Reset image failure state when base changes
-  useEffect(() => {
-    setNormalImageFailed(false)
-    setHyperspaceImageFailed(false)
-  }, [selectedKey])
 
   // Auto-select aspect when only one option available
   useEffect(() => {
@@ -97,21 +89,10 @@ export function useSwuSetup(
     localStorage.setItem(HYPERSPACE_PREF_KEY, String(value))
   }
 
-  const handleSubmit = () => {
+  const handleSubmit = (effectiveHyperspace: boolean) => {
     if (!selectedBase) return
-    const hasHyperspace = !!(selectedBase.hyperspaceArtHiRes || selectedBase.hyperspaceArt)
-    const effectiveHyperspace = useHyperspace || (normalImageFailed && hasHyperspace)
     onConfirm(selectedBase, effectiveHyperspace)
   }
-
-  const handleNormalImageFailed = () => setNormalImageFailed(true)
-  const handleHyperspaceImageFailed = () => setHyperspaceImageFailed(true)
-
-  const showHyperspaceToggle = !!(
-    (selectedBase?.hyperspaceArtHiRes || selectedBase?.hyperspaceArt) &&
-    !hyperspaceImageFailed &&
-    !normalImageFailed
-  )
 
   return {
     loading,
@@ -124,15 +105,10 @@ export function useSwuSetup(
     availableSets,
     availableAspects,
     filteredBases,
-    normalImageFailed,
-    hyperspaceImageFailed,
-    showHyperspaceToggle,
     handleSetChange,
     handleAspectChange,
     handleKeyChange,
     handleHyperspaceToggle,
     handleSubmit,
-    handleNormalImageFailed,
-    handleHyperspaceImageFailed,
   }
 }

--- a/src/test/swuSetupScreen.test.tsx
+++ b/src/test/swuSetupScreen.test.tsx
@@ -467,35 +467,7 @@ describe('SwuSetupScreen', () => {
     expect(img).toHaveAttribute('src', mockBases[0].frontArt)
   })
 
-  it('Shows "Hyperspace variant not found" when hyperspace image fails but normal loads', async () => {
-    const user = userEvent.setup()
-    render(<SwuSetupScreen onConfirm={vi.fn()} onHelp={vi.fn()} />)
-    await waitFor(() => expect(screen.getAllByRole('combobox')).toHaveLength(3))
-    await user.selectOptions(screen.getAllByRole('combobox')[0], 'SOR')
-    await user.selectOptions(screen.getAllByRole('combobox')[1], 'Aggression')
-    await user.selectOptions(screen.getAllByRole('combobox')[2], 'SOR-026')
-    await user.click(screen.getByLabelText('Hyperspace variant'))
-    fireEvent.error(screen.getByAltText('Catacombs of Cadera'))
-    await waitFor(() => {
-      expect(screen.getByText('Hyperspace variant not found')).toBeInTheDocument()
-      expect(screen.queryByLabelText('Hyperspace variant')).not.toBeInTheDocument()
-    })
-  })
-
-  it('Shows "Only hyperspace image available" when normal fails but hyperspace loads', async () => {
-    const user = userEvent.setup()
-    render(<SwuSetupScreen onConfirm={vi.fn()} onHelp={vi.fn()} />)
-    await waitFor(() => expect(screen.getAllByRole('combobox')).toHaveLength(3))
-    await user.selectOptions(screen.getAllByRole('combobox')[0], 'SOR')
-    await user.selectOptions(screen.getAllByRole('combobox')[1], 'Aggression')
-    await user.selectOptions(screen.getAllByRole('combobox')[2], 'SOR-026')
-    fireEvent.error(screen.getByAltText('Catacombs of Cadera'))
-    await waitFor(() => {
-      expect(screen.getByText('Only hyperspace image available')).toBeInTheDocument()
-    })
-  })
-
-  it('Shows "No base images found" when normal image fails and no hyperspace exists', async () => {
+  it('Shows an error message when all art fails', async () => {
     const user = userEvent.setup()
     render(<SwuSetupScreen onConfirm={vi.fn()} onHelp={vi.fn()} />)
     await waitFor(() => expect(screen.getAllByRole('combobox')).toHaveLength(3))
@@ -504,7 +476,6 @@ describe('SwuSetupScreen', () => {
     await user.selectOptions(screen.getAllByRole('combobox')[2], 'LAW-021')
     // In this test, swuapi returns empty so LAW is processed via the swu-db-only
     // path, giving frontArtLowRes=null. One error exhausts all normal art options.
-    // (In the real app, LAW has frontArtLowRes from swuapi so two errors are needed.)
     fireEvent.error(screen.getByAltText('Coaxium Mine'))
     await waitFor(() => expect(screen.getByText('No base images found')).toBeInTheDocument())
   })

--- a/src/test/useBaseArt.test.ts
+++ b/src/test/useBaseArt.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useBaseArt } from '../hooks/useBaseArt'
+import { Base } from '../hooks/useBases'
+
+// All four art URLs present
+const fullBase: Base = {
+  set: 'LAW', number: '021', name: 'Coaxium Mine', subtitle: 'Kessel', hp: 27,
+  frontArt: 'https://cdn/LAW/021.png',
+  frontArtLowRes: 'https://swuapi/coaxium.png',
+  hyperspaceArtHiRes: 'https://cdn/LAW/285.png',
+  hyperspaceArt: 'https://swuapi/coaxium-hs.png',
+  epicAction: '', aspects: ['Vigilance'], rarity: 'Common',
+}
+
+// frontArt only — no low-res, no hyperspace
+const sparseBase: Base = {
+  set: 'SOR', number: '021', name: 'Dagobah Swamp', subtitle: 'Dagobah', hp: 30,
+  frontArt: 'https://cdn/SOR/021.png',
+  frontArtLowRes: null,
+  hyperspaceArtHiRes: null,
+  hyperspaceArt: null,
+  epicAction: '', aspects: ['Vigilance'], rarity: 'Common',
+}
+
+// frontArt + hyperspaceArtHiRes only (typical SOR base)
+const hyperspaceBase: Base = {
+  set: 'SOR', number: '026', name: 'Catacombs of Cadera', subtitle: 'Jedha', hp: 30,
+  frontArt: 'https://cdn/SOR/026.png',
+  frontArtLowRes: null,
+  hyperspaceArtHiRes: 'https://cdn/SOR/292.png',
+  hyperspaceArt: null,
+  epicAction: '', aspects: ['Aggression'], rarity: 'Common',
+}
+
+const otherBase: Base = {
+  set: 'SOR', number: '022', name: 'Energy Conversion Lab', subtitle: 'Eadu', hp: 25,
+  frontArt: 'https://cdn/SOR/022.png',
+  frontArtLowRes: null,
+  hyperspaceArtHiRes: 'https://cdn/SOR/288.png',
+  hyperspaceArt: null,
+  epicAction: '', aspects: ['Cunning'], rarity: 'Rare',
+}
+
+describe('useBaseArt', () => {
+
+  // --- Null base ---
+
+  it('src is null when base is null', () => {
+    const { result } = renderHook(() => useBaseArt(null, false))
+    expect(result.current.src).toBeNull()
+  })
+
+  it('allFailed is true when base is null', () => {
+    const { result } = renderHook(() => useBaseArt(null, false))
+    expect(result.current.allFailed).toBe(true)
+  })
+
+  // --- Initial state: normal preferred ---
+
+  it('src is frontArt initially when useHyperspace is false', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, false))
+    expect(result.current.src).toBe(fullBase.frontArt)
+  })
+
+  it('isHyperspace is false initially when useHyperspace is false', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, false))
+    expect(result.current.isHyperspace).toBe(false)
+  })
+
+  it('allFailed is false initially', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, false))
+    expect(result.current.allFailed).toBe(false)
+  })
+
+  it('normalFailed is false initially', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, false))
+    expect(result.current.normalFailed).toBe(false)
+  })
+
+  it('hyperspaceFailed is false initially', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, false))
+    expect(result.current.hyperspaceFailed).toBe(false)
+  })
+
+  // --- Initial state: hyperspace preferred ---
+
+  it('src is hyperspaceArtHiRes initially when useHyperspace is true', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, true))
+    expect(result.current.src).toBe(fullBase.hyperspaceArtHiRes)
+  })
+
+  it('isHyperspace is true initially when useHyperspace is true', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, true))
+    expect(result.current.isHyperspace).toBe(true)
+  })
+
+  it('falls back to frontArt when useHyperspace is true but no hyperspace URLs exist', () => {
+    const { result } = renderHook(() => useBaseArt(sparseBase, true))
+    expect(result.current.src).toBe(sparseBase.frontArt)
+  })
+
+  // --- Normal-preferred fallback chain ---
+
+  it('advances to frontArtLowRes after one error (normal preferred)', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, false))
+    act(() => result.current.onError())
+    expect(result.current.src).toBe(fullBase.frontArtLowRes)
+  })
+
+  it('advances to hyperspaceArtHiRes after two errors (normal preferred)', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, false))
+    act(() => result.current.onError())
+    act(() => result.current.onError())
+    expect(result.current.src).toBe(fullBase.hyperspaceArtHiRes)
+  })
+
+  it('advances to hyperspaceArt after three errors (normal preferred)', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, false))
+    act(() => result.current.onError())
+    act(() => result.current.onError())
+    act(() => result.current.onError())
+    expect(result.current.src).toBe(fullBase.hyperspaceArt)
+  })
+
+  it('allFailed is true after all four URLs error (normal preferred)', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, false))
+    act(() => result.current.onError())
+    act(() => result.current.onError())
+    act(() => result.current.onError())
+    act(() => result.current.onError())
+    expect(result.current.allFailed).toBe(true)
+  })
+
+  it('allFailed is true after one error on a base with only frontArt', () => {
+    const { result } = renderHook(() => useBaseArt(sparseBase, false))
+    act(() => result.current.onError())
+    expect(result.current.allFailed).toBe(true)
+  })
+
+  // --- Hyperspace-preferred fallback chain ---
+
+  it('advances to hyperspaceArt after one error (hyperspace preferred)', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, true))
+    act(() => result.current.onError())
+    expect(result.current.src).toBe(fullBase.hyperspaceArt)
+  })
+
+  it('advances to frontArt after two errors (hyperspace preferred)', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, true))
+    act(() => result.current.onError())
+    act(() => result.current.onError())
+    expect(result.current.src).toBe(fullBase.frontArt)
+  })
+
+  it('advances to frontArtLowRes after three errors (hyperspace preferred)', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, true))
+    act(() => result.current.onError())
+    act(() => result.current.onError())
+    act(() => result.current.onError())
+    expect(result.current.src).toBe(fullBase.frontArtLowRes)
+  })
+
+  it('allFailed is true after all four URLs error (hyperspace preferred)', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, true))
+    act(() => result.current.onError())
+    act(() => result.current.onError())
+    act(() => result.current.onError())
+    act(() => result.current.onError())
+    expect(result.current.allFailed).toBe(true)
+  })
+
+  // --- isHyperspace transitions ---
+
+  it('isHyperspace becomes true when normal art exhausted and fallback shows hyperspace', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, false))
+    act(() => result.current.onError())
+    act(() => result.current.onError())
+    expect(result.current.isHyperspace).toBe(true)
+  })
+
+  it('isHyperspace becomes false when hyperspace art exhausted and fallback shows normal', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, true))
+    act(() => result.current.onError())
+    act(() => result.current.onError())
+    expect(result.current.isHyperspace).toBe(false)
+  })
+
+  // --- normalFailed and hyperspaceFailed ---
+
+  it('normalFailed becomes true once all normal URLs are exhausted', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, false))
+    act(() => result.current.onError())
+    expect(result.current.normalFailed).toBe(false)
+    act(() => result.current.onError())
+    expect(result.current.normalFailed).toBe(true)
+  })
+
+  it('hyperspaceFailed becomes true once all hyperspace URLs are exhausted', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, false))
+    act(() => result.current.onError())
+    act(() => result.current.onError())
+    act(() => result.current.onError())
+    expect(result.current.hyperspaceFailed).toBe(false)
+    act(() => result.current.onError())
+    expect(result.current.hyperspaceFailed).toBe(true)
+  })
+
+  it('normalFailed is false for a base with no normal URLs', () => {
+    const hyperOnly: Base = {
+      set: 'SOR', number: '026', name: 'Test', subtitle: '', hp: 30,
+      frontArt: null, frontArtLowRes: null,
+      hyperspaceArtHiRes: 'https://cdn/SOR/292.png', hyperspaceArt: null,
+      epicAction: '', aspects: [], rarity: 'Common',
+    }
+    const { result } = renderHook(() => useBaseArt(hyperOnly, false))
+    act(() => result.current.onError())
+    expect(result.current.normalFailed).toBe(false)
+  })
+
+  // --- imageLoaded ---
+
+  it('imageLoaded starts false', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, false))
+    expect(result.current.imageLoaded).toBe(false)
+  })
+
+  it('imageLoaded becomes true after onLoad', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, false))
+    act(() => result.current.onLoad())
+    expect(result.current.imageLoaded).toBe(true)
+  })
+
+  it('imageLoaded resets to false after onError advances to next URL', () => {
+    const { result } = renderHook(() => useBaseArt(fullBase, false))
+    act(() => result.current.onLoad())
+    act(() => result.current.onError())
+    expect(result.current.imageLoaded).toBe(false)
+  })
+
+  // --- Reset on base change ---
+
+  it('resets to first URL when base changes', () => {
+    let currentBase: Base = hyperspaceBase
+    const { result, rerender } = renderHook(() => useBaseArt(currentBase, false))
+    act(() => result.current.onError())
+    expect(result.current.src).toBe(hyperspaceBase.hyperspaceArtHiRes)
+    currentBase = otherBase
+    rerender()
+    expect(result.current.src).toBe(otherBase.frontArt)
+  })
+
+  it('resets imageLoaded when base changes', () => {
+    let currentBase: Base = hyperspaceBase
+    const { result, rerender } = renderHook(() => useBaseArt(currentBase, false))
+    act(() => result.current.onLoad())
+    currentBase = otherBase
+    rerender()
+    expect(result.current.imageLoaded).toBe(false)
+  })
+
+})

--- a/src/test/useSwuGame.test.ts
+++ b/src/test/useSwuGame.test.ts
@@ -4,24 +4,10 @@ import { useSwuGame } from '../hooks/useSwuGame'
 
 describe('useSwuGame', () => {
 
-  // --- Initial state ---
-
   it('Counter starts at zero', () => {
     const { result } = renderHook(() => useSwuGame())
     expect(result.current.count).toBe(0)
   })
-
-  it('imageLoaded starts as false', () => {
-    const { result } = renderHook(() => useSwuGame())
-    expect(result.current.imageLoaded).toBe(false)
-  })
-
-  it('imageError starts as false', () => {
-    const { result } = renderHook(() => useSwuGame())
-    expect(result.current.imageError).toBe(false)
-  })
-
-  // --- Counter ---
 
   it('increment increases count by 1', () => {
     const { result } = renderHook(() => useSwuGame())
@@ -52,67 +38,6 @@ describe('useSwuGame', () => {
     act(() => result.current.decrement())
     act(() => result.current.decrement())
     expect(result.current.count).toBe(0)
-  })
-
-  // --- Image state ---
-
-  it('handleImageLoad sets imageLoaded to true', () => {
-    const { result } = renderHook(() => useSwuGame())
-    act(() => result.current.handleImageLoad())
-    expect(result.current.imageLoaded).toBe(true)
-  })
-
-  it('handleImageError sets imageError to true when no imageSrcs provided', () => {
-    const { result } = renderHook(() => useSwuGame())
-    act(() => result.current.handleImageError())
-    expect(result.current.imageError).toBe(true)
-  })
-
-  // --- Image src fallback ---
-
-  it('currentImageSrc is empty string when no imageSrcs provided', () => {
-    const { result } = renderHook(() => useSwuGame())
-    expect(result.current.currentImageSrc).toBe('')
-  })
-
-  it('currentImageSrc returns the first URL', () => {
-    const { result } = renderHook(() => useSwuGame(['url1', 'url2']))
-    expect(result.current.currentImageSrc).toBe('url1')
-  })
-
-  it('handleImageError advances to the next URL when more are available', () => {
-    const { result } = renderHook(() => useSwuGame(['url1', 'url2']))
-    act(() => result.current.handleImageError())
-    expect(result.current.currentImageSrc).toBe('url2')
-  })
-
-  it('handleImageError does not set imageError when advancing to next URL', () => {
-    const { result } = renderHook(() => useSwuGame(['url1', 'url2']))
-    act(() => result.current.handleImageError())
-    expect(result.current.imageError).toBe(false)
-  })
-
-  it('handleImageError resets imageLoaded when advancing to next URL', () => {
-    const { result } = renderHook(() => useSwuGame(['url1', 'url2']))
-    act(() => result.current.handleImageLoad())
-    act(() => result.current.handleImageError())
-    expect(result.current.imageLoaded).toBe(false)
-  })
-
-  it('handleImageError sets imageError when all URLs are exhausted', () => {
-    const { result } = renderHook(() => useSwuGame(['url1']))
-    act(() => result.current.handleImageError())
-    expect(result.current.imageError).toBe(true)
-  })
-
-  it('handleImageError steps through all URLs before setting imageError', () => {
-    const { result } = renderHook(() => useSwuGame(['url1', 'url2', 'url3']))
-    act(() => result.current.handleImageError())
-    act(() => result.current.handleImageError())
-    expect(result.current.currentImageSrc).toBe('url3')
-    expect(result.current.imageError).toBe(false)
-    act(() => result.current.handleImageError())
-    expect(result.current.imageError).toBe(true)
   })
 
 })

--- a/src/test/useSwuSetup.test.ts
+++ b/src/test/useSwuSetup.test.ts
@@ -276,152 +276,23 @@ describe('useSwuSetup', () => {
     expect(setItem).toHaveBeenCalledWith('pref_hyperspace', 'true')
   })
 
-  // --- showHyperspaceToggle ---
-
-  it('showHyperspaceToggle is false when no base is selected', () => {
-    const { result } = renderHook(() => useSwuSetup(vi.fn()))
-    expect(result.current.showHyperspaceToggle).toBe(false)
-  })
-
-  it('showHyperspaceToggle is true when selected base has hyperspaceArt and no image failures', () => {
-    const { result } = renderHook(() => useSwuSetup(vi.fn()))
-    act(() => result.current.handleSetChange('SOR'))
-    act(() => result.current.handleAspectChange('Aggression'))
-    act(() => result.current.handleKeyChange('SOR-026'))
-    expect(result.current.showHyperspaceToggle).toBe(true)
-  })
-
-  it('showHyperspaceToggle is false when selected base has no hyperspaceArt', () => {
-    const { result } = renderHook(() => useSwuSetup(vi.fn()))
-    act(() => result.current.handleSetChange('TWI'))
-    act(() => result.current.handleAspectChange('Aggression'))
-    act(() => result.current.handleKeyChange('TWI-001'))
-    expect(result.current.showHyperspaceToggle).toBe(false)
-  })
-
-  it('showHyperspaceToggle is false after hyperspace image fails', () => {
-    const { result } = renderHook(() => useSwuSetup(vi.fn()))
-    act(() => result.current.handleSetChange('SOR'))
-    act(() => result.current.handleAspectChange('Aggression'))
-    act(() => result.current.handleKeyChange('SOR-026'))
-    act(() => result.current.handleHyperspaceImageFailed())
-    expect(result.current.showHyperspaceToggle).toBe(false)
-  })
-
-  it('showHyperspaceToggle is false after normal image fails', () => {
-    const { result } = renderHook(() => useSwuSetup(vi.fn()))
-    act(() => result.current.handleSetChange('SOR'))
-    act(() => result.current.handleAspectChange('Aggression'))
-    act(() => result.current.handleKeyChange('SOR-026'))
-    act(() => result.current.handleNormalImageFailed())
-    expect(result.current.showHyperspaceToggle).toBe(false)
-  })
-
-  // --- Image failure reset ---
-
-  it('image failure flags reset when selected key changes', () => {
-    const { result } = renderHook(() => useSwuSetup(vi.fn()))
-    act(() => result.current.handleSetChange('SOR'))
-    act(() => result.current.handleAspectChange('Aggression'))
-    act(() => result.current.handleKeyChange('SOR-026'))
-    act(() => result.current.handleNormalImageFailed())
-    // Change to a different base (need Cunning for baseB)
-    act(() => result.current.handleAspectChange('Cunning'))
-    act(() => result.current.handleKeyChange('SOR-022'))
-    // After key change, image failures should reset — showHyperspaceToggle driven by absence of hyperspaceArt, not failure flags
-    expect(result.current.normalImageFailed).toBe(false)
-    expect(result.current.hyperspaceImageFailed).toBe(false)
-  })
-
   // --- handleSubmit ---
 
-  it('handleSubmit calls onConfirm with selectedBase and useHyperspace', () => {
+  it('handleSubmit calls onConfirm with selectedBase and effectiveHyperspace', () => {
     const onConfirm = vi.fn()
     const { result } = renderHook(() => useSwuSetup(onConfirm))
     act(() => result.current.handleSetChange('SOR'))
     act(() => result.current.handleAspectChange('Aggression'))
     act(() => result.current.handleKeyChange('SOR-026'))
-    act(() => result.current.handleSubmit())
+    act(() => result.current.handleSubmit(false))
     expect(onConfirm).toHaveBeenCalledWith(baseA, false)
   })
 
   it('handleSubmit does nothing when no base is selected', () => {
     const onConfirm = vi.fn()
     const { result } = renderHook(() => useSwuSetup(onConfirm))
-    act(() => result.current.handleSubmit())
+    act(() => result.current.handleSubmit(false))
     expect(onConfirm).not.toHaveBeenCalled()
-  })
-
-  it('handleSubmit passes current useHyperspace value to onConfirm', () => {
-    const onConfirm = vi.fn()
-    const { result } = renderHook(() => useSwuSetup(onConfirm))
-    act(() => result.current.handleSetChange('SOR'))
-    act(() => result.current.handleAspectChange('Aggression'))
-    act(() => result.current.handleKeyChange('SOR-026'))
-    act(() => result.current.handleHyperspaceToggle(true))
-    act(() => result.current.handleSubmit())
-    expect(onConfirm).toHaveBeenCalledWith(baseA, true)
-  })
-
-  it('handleSubmit passes useHyperspace: true when normal art failed but hyperspace art exists', () => {
-    const onConfirm = vi.fn()
-    const { result } = renderHook(() => useSwuSetup(onConfirm))
-    act(() => result.current.handleSetChange('SOR'))
-    act(() => result.current.handleAspectChange('Aggression'))
-    act(() => result.current.handleKeyChange('SOR-026'))
-    act(() => result.current.handleNormalImageFailed())
-    act(() => result.current.handleSubmit())
-    // useHyperspace preference is false, but normal art has failed — hyperspace must be used
-    expect(onConfirm).toHaveBeenCalledWith(baseA, true)
-  })
-
-  it('handleSubmit respects useHyperspace: false when normal art has not failed', () => {
-    const onConfirm = vi.fn()
-    const { result } = renderHook(() => useSwuSetup(onConfirm))
-    act(() => result.current.handleSetChange('SOR'))
-    act(() => result.current.handleAspectChange('Aggression'))
-    act(() => result.current.handleKeyChange('SOR-026'))
-    act(() => result.current.handleSubmit())
-    expect(onConfirm).toHaveBeenCalledWith(baseA, false)
-  })
-
-  // --- initialSelection ---
-
-  it('Pre-populates selectedSet from initialSelection', () => {
-    const { result } = renderHook(() =>
-      useSwuSetup(vi.fn(), { set: 'SOR', aspect: 'Aggression', key: 'SOR-026' })
-    )
-    expect(result.current.selectedSet).toBe('SOR')
-  })
-
-  it('Pre-populates selectedAspect from initialSelection', () => {
-    const { result } = renderHook(() =>
-      useSwuSetup(vi.fn(), { set: 'SOR', aspect: 'Aggression', key: 'SOR-026' })
-    )
-    expect(result.current.selectedAspect).toBe('Aggression')
-  })
-
-  it('Pre-populates selectedKey from initialSelection', () => {
-    const { result } = renderHook(() =>
-      useSwuSetup(vi.fn(), { set: 'SOR', aspect: 'Aggression', key: 'SOR-026' })
-    )
-    expect(result.current.selectedKey).toBe('SOR-026')
-  })
-
-  it('Resolves selectedBase from initialSelection once bases are loaded', () => {
-    const { result } = renderHook(() =>
-      useSwuSetup(vi.fn(), { set: 'SOR', aspect: 'Aggression', key: 'SOR-026' })
-    )
-    expect(result.current.selectedBase).toEqual(baseA)
-  })
-
-  it('Submit button is immediately active when initialSelection matches a loaded base', () => {
-    const onConfirm = vi.fn()
-    const { result } = renderHook(() =>
-      useSwuSetup(onConfirm, { set: 'SOR', aspect: 'Aggression', key: 'SOR-026' })
-    )
-    act(() => result.current.handleSubmit())
-    expect(onConfirm).toHaveBeenCalledWith(baseA, false)
   })
 
 })

--- a/src/test/useSwuSetup.test.ts
+++ b/src/test/useSwuSetup.test.ts
@@ -276,113 +276,23 @@ describe('useSwuSetup', () => {
     expect(setItem).toHaveBeenCalledWith('pref_hyperspace', 'true')
   })
 
-  // --- showHyperspaceToggle ---
-
-  it('showHyperspaceToggle is false when no base is selected', () => {
-    const { result } = renderHook(() => useSwuSetup(vi.fn()))
-    expect(result.current.showHyperspaceToggle).toBe(false)
-  })
-
-  it('showHyperspaceToggle is true when selected base has hyperspaceArt and no image failures', () => {
-    const { result } = renderHook(() => useSwuSetup(vi.fn()))
-    act(() => result.current.handleSetChange('SOR'))
-    act(() => result.current.handleAspectChange('Aggression'))
-    act(() => result.current.handleKeyChange('SOR-026'))
-    expect(result.current.showHyperspaceToggle).toBe(true)
-  })
-
-  it('showHyperspaceToggle is false when selected base has no hyperspaceArt', () => {
-    const { result } = renderHook(() => useSwuSetup(vi.fn()))
-    act(() => result.current.handleSetChange('TWI'))
-    act(() => result.current.handleAspectChange('Aggression'))
-    act(() => result.current.handleKeyChange('TWI-001'))
-    expect(result.current.showHyperspaceToggle).toBe(false)
-  })
-
-  it('showHyperspaceToggle is false after hyperspace image fails', () => {
-    const { result } = renderHook(() => useSwuSetup(vi.fn()))
-    act(() => result.current.handleSetChange('SOR'))
-    act(() => result.current.handleAspectChange('Aggression'))
-    act(() => result.current.handleKeyChange('SOR-026'))
-    act(() => result.current.handleHyperspaceImageFailed())
-    expect(result.current.showHyperspaceToggle).toBe(false)
-  })
-
-  it('showHyperspaceToggle is false after normal image fails', () => {
-    const { result } = renderHook(() => useSwuSetup(vi.fn()))
-    act(() => result.current.handleSetChange('SOR'))
-    act(() => result.current.handleAspectChange('Aggression'))
-    act(() => result.current.handleKeyChange('SOR-026'))
-    act(() => result.current.handleNormalImageFailed())
-    expect(result.current.showHyperspaceToggle).toBe(false)
-  })
-
-  // --- Image failure reset ---
-
-  it('image failure flags reset when selected key changes', () => {
-    const { result } = renderHook(() => useSwuSetup(vi.fn()))
-    act(() => result.current.handleSetChange('SOR'))
-    act(() => result.current.handleAspectChange('Aggression'))
-    act(() => result.current.handleKeyChange('SOR-026'))
-    act(() => result.current.handleNormalImageFailed())
-    // Change to a different base (need Cunning for baseB)
-    act(() => result.current.handleAspectChange('Cunning'))
-    act(() => result.current.handleKeyChange('SOR-022'))
-    // After key change, image failures should reset — showHyperspaceToggle driven by absence of hyperspaceArt, not failure flags
-    expect(result.current.normalImageFailed).toBe(false)
-    expect(result.current.hyperspaceImageFailed).toBe(false)
-  })
-
   // --- handleSubmit ---
 
-  it('handleSubmit calls onConfirm with selectedBase and useHyperspace', () => {
+  it('handleSubmit calls onConfirm with selectedBase and effectiveHyperspace', () => {
     const onConfirm = vi.fn()
     const { result } = renderHook(() => useSwuSetup(onConfirm))
     act(() => result.current.handleSetChange('SOR'))
     act(() => result.current.handleAspectChange('Aggression'))
     act(() => result.current.handleKeyChange('SOR-026'))
-    act(() => result.current.handleSubmit())
+    act(() => result.current.handleSubmit(false))
     expect(onConfirm).toHaveBeenCalledWith(baseA, false)
   })
 
   it('handleSubmit does nothing when no base is selected', () => {
     const onConfirm = vi.fn()
     const { result } = renderHook(() => useSwuSetup(onConfirm))
-    act(() => result.current.handleSubmit())
+    act(() => result.current.handleSubmit(false))
     expect(onConfirm).not.toHaveBeenCalled()
-  })
-
-  it('handleSubmit passes current useHyperspace value to onConfirm', () => {
-    const onConfirm = vi.fn()
-    const { result } = renderHook(() => useSwuSetup(onConfirm))
-    act(() => result.current.handleSetChange('SOR'))
-    act(() => result.current.handleAspectChange('Aggression'))
-    act(() => result.current.handleKeyChange('SOR-026'))
-    act(() => result.current.handleHyperspaceToggle(true))
-    act(() => result.current.handleSubmit())
-    expect(onConfirm).toHaveBeenCalledWith(baseA, true)
-  })
-
-  it('handleSubmit passes useHyperspace: true when normal art failed but hyperspace art exists', () => {
-    const onConfirm = vi.fn()
-    const { result } = renderHook(() => useSwuSetup(onConfirm))
-    act(() => result.current.handleSetChange('SOR'))
-    act(() => result.current.handleAspectChange('Aggression'))
-    act(() => result.current.handleKeyChange('SOR-026'))
-    act(() => result.current.handleNormalImageFailed())
-    act(() => result.current.handleSubmit())
-    // useHyperspace preference is false, but normal art has failed — hyperspace must be used
-    expect(onConfirm).toHaveBeenCalledWith(baseA, true)
-  })
-
-  it('handleSubmit respects useHyperspace: false when normal art has not failed', () => {
-    const onConfirm = vi.fn()
-    const { result } = renderHook(() => useSwuSetup(onConfirm))
-    act(() => result.current.handleSetChange('SOR'))
-    act(() => result.current.handleAspectChange('Aggression'))
-    act(() => result.current.handleKeyChange('SOR-026'))
-    act(() => result.current.handleSubmit())
-    expect(onConfirm).toHaveBeenCalledWith(baseA, false)
   })
 
 })


### PR DESCRIPTION
Ensures the same art selection and fallback logic used on both the setup and game screens

Closes #43 