### PR TITLE
bug/premature-toggle-rendering 

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -253,7 +253,7 @@ frontArt → frontArtLowRes → hyperspaceArtHiRes → hyperspaceArt → text/er
 
 The normal-preferred chain always falls back to hyperspace art before giving up — a base image is always better than a text fallback.
 
-The setup screen uses `normalFailed` and `hyperspaceFailed` to show contextual messages ("Only hyperspace image available", "Hyperspace variant not found") and to hide the hyperspace toggle when either tier has been exhausted. The game screen uses `allFailed` to switch to the text fallback (base name, subtitle, epic action).
+The setup screen uses `normalFailed`, `hyperspaceFailed`, and `imageLoaded` to control the hyperspace toggle and contextual messages ("Only hyperspace image available", "Hyperspace variant not found"): both are suppressed until `imageLoaded` is true, preventing flicker during the loading window. The game screen uses `allFailed` to switch to the text fallback (base name, subtitle, epic action).
 
 ### Caching
 

--- a/src/components/imagePreview.tsx
+++ b/src/components/imagePreview.tsx
@@ -5,7 +5,9 @@ interface ImagePreviewProps {
   src: string | null
   isHyperspace: boolean
   allFailed: boolean
+  imageLoaded: boolean
   useHyperspace: boolean
+  onLoad: () => void
   onError: () => void
 }
 
@@ -32,20 +34,20 @@ const errorStyle: React.CSSProperties = {
   fontStyle: 'italic',
 }
 
-function ImagePreview({ base, src, isHyperspace, allFailed, useHyperspace, onError }: ImagePreviewProps) {
+function ImagePreview({ base, src, isHyperspace, allFailed, imageLoaded, useHyperspace, onLoad, onError }: ImagePreviewProps) {
   if (allFailed || !src) {
     return <p style={errorStyle}>No base images found</p>
   }
 
-  const message = (!useHyperspace && isHyperspace)
+  const message = imageLoaded && ((!useHyperspace && isHyperspace)
     ? 'Only hyperspace image available'
     : (useHyperspace && !isHyperspace)
       ? 'Hyperspace variant not found'
-      : null
+      : null)
 
   return (
     <>
-      <img src={src} alt={base.name} onError={onError} style={imgStyle} />
+      <img src={src} alt={base.name} onLoad={onLoad} onError={onError} style={imgStyle} />
       {message && <p style={messageStyle}>{message}</p>}
     </>
   )

--- a/src/components/swuSetupScreen.tsx
+++ b/src/components/swuSetupScreen.tsx
@@ -16,7 +16,7 @@ function SwuSetupScreen({ onConfirm, onHelp, initialSelection }: Props) {
   const hasHyperspace = !!(
     setup.selectedBase?.hyperspaceArtHiRes || setup.selectedBase?.hyperspaceArt
   )
-  const showHyperspaceToggle = hasHyperspace && !art.normalFailed && !art.hyperspaceFailed
+  const showHyperspaceToggle = hasHyperspace && !art.normalFailed && !art.hyperspaceFailed && art.imageLoaded
 
   const handleSubmit = () => {
     const effectiveHyperspace = setup.useHyperspace || art.normalFailed
@@ -39,6 +39,8 @@ function SwuSetupScreen({ onConfirm, onHelp, initialSelection }: Props) {
       artSrc={art.src}
       artIsHyperspace={art.isHyperspace}
       artAllFailed={art.allFailed}
+      artImageLoaded={art.imageLoaded}
+      onArtLoad={art.onLoad}
       onArtError={art.onError}
       onSetChange={setup.handleSetChange}
       onAspectChange={setup.handleAspectChange}

--- a/src/components/swuSetupScreenView.tsx
+++ b/src/components/swuSetupScreenView.tsx
@@ -17,6 +17,8 @@ interface Props {
   artSrc: string | null
   artIsHyperspace: boolean
   artAllFailed: boolean
+  artImageLoaded: boolean
+  onArtLoad: () => void
   onArtError: () => void
   onSetChange: (set: string) => void
   onAspectChange: (aspect: string) => void
@@ -59,6 +61,8 @@ function SwuSetupScreenView({
   artSrc,
   artIsHyperspace,
   artAllFailed,
+  artImageLoaded,
+  onArtLoad,
   onArtError,
   onSetChange,
   onAspectChange,
@@ -290,7 +294,9 @@ function SwuSetupScreenView({
                   src={artSrc}
                   isHyperspace={artIsHyperspace}
                   allFailed={artAllFailed}
+                  imageLoaded={artImageLoaded}
                   useHyperspace={useHyperspace}
+                  onLoad={onArtLoad}
                   onError={onArtError}
                 />
 

--- a/src/test/swuSetupScreen.test.tsx
+++ b/src/test/swuSetupScreen.test.tsx
@@ -381,6 +381,7 @@ describe('SwuSetupScreen', () => {
     await user.selectOptions(screen.getAllByRole('combobox')[0], 'SOR')
     await user.selectOptions(screen.getAllByRole('combobox')[1], 'Aggression')
     await user.selectOptions(screen.getAllByRole('combobox')[2], 'SOR-026')
+    fireEvent.load(screen.getByAltText('Catacombs of Cadera'))
     expect(screen.getByLabelText('Hyperspace variant')).toBeInTheDocument()
   })
 
@@ -402,6 +403,7 @@ describe('SwuSetupScreen', () => {
     await user.selectOptions(screen.getAllByRole('combobox')[0], 'SOR')
     await user.selectOptions(screen.getAllByRole('combobox')[1], 'Aggression')
     await user.selectOptions(screen.getAllByRole('combobox')[2], 'SOR-026')
+    fireEvent.load(screen.getByAltText('Catacombs of Cadera'))
     const toggle = screen.getByLabelText('Hyperspace variant') as HTMLInputElement
     expect(toggle.checked).toBe(false)
   })
@@ -422,6 +424,7 @@ describe('SwuSetupScreen', () => {
     await user.selectOptions(screen.getAllByRole('combobox')[0], 'SOR')
     await user.selectOptions(screen.getAllByRole('combobox')[1], 'Aggression')
     await user.selectOptions(screen.getAllByRole('combobox')[2], 'SOR-026')
+    fireEvent.load(screen.getByAltText('Catacombs of Cadera'))
     const toggle = screen.getByLabelText('Hyperspace variant') as HTMLInputElement
     expect(toggle.checked).toBe(true)
   })
@@ -440,6 +443,7 @@ describe('SwuSetupScreen', () => {
     await user.selectOptions(screen.getAllByRole('combobox')[0], 'SOR')
     await user.selectOptions(screen.getAllByRole('combobox')[1], 'Aggression')
     await user.selectOptions(screen.getAllByRole('combobox')[2], 'SOR-026')
+    fireEvent.load(screen.getByAltText('Catacombs of Cadera'))
     await user.click(screen.getByLabelText('Hyperspace variant'))
     expect(setItemMock).toHaveBeenCalledWith('pref_hyperspace', 'true')
   })
@@ -451,6 +455,7 @@ describe('SwuSetupScreen', () => {
     await user.selectOptions(screen.getAllByRole('combobox')[0], 'SOR')
     await user.selectOptions(screen.getAllByRole('combobox')[1], 'Aggression')
     await user.selectOptions(screen.getAllByRole('combobox')[2], 'SOR-026')
+    fireEvent.load(screen.getByAltText('Catacombs of Cadera'))
     await user.click(screen.getByLabelText('Hyperspace variant'))
     const img = screen.getByAltText('Catacombs of Cadera')
     expect(img).toHaveAttribute('src', mockBases[0].hyperspaceArtHiRes)


### PR DESCRIPTION
fixes the order of the hyperspace toggle and error message rendering

Closes #44 