### PR TITLE
bug/rotated-hyperspace-images 

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -253,6 +253,8 @@ frontArt → frontArtLowRes → hyperspaceArtHiRes → hyperspaceArt → text/er
 
 The normal-preferred chain always falls back to hyperspace art before giving up — a base image is always better than a text fallback.
 
+Some hi-res hyperspace images on cdn.swu-db.com are stored rotated 90°. `useBaseArt` calls `getRotationFromHyperspaceUrl` for each hyperspace hi-res entry and includes the correction as `rotationDeg` in the returned state. When `rotationDeg` is non-zero, both views switch to a portrait layout box sized to the card’s inverse dimensions (`CARD_H/CARD_W` wide × `CARD_W/CARD_H` tall), centered with `translate(-50%,-50%) rotate(90deg)`, so the rotated visual output fills the landscape container without overflowing or changing aspect ratio. When `rotationDeg` is zero the image fills the container normally (`inset:0; width:100%; height:100%`). The lookup table in `src/constants/rotatedCards.ts` is the single place to add new entries as they are discovered.
+
 The setup screen uses `normalFailed`, `hyperspaceFailed`, and `imageLoaded` to control the hyperspace toggle and contextual messages ("Only hyperspace image available", "Hyperspace variant not found"): both are suppressed until `imageLoaded` is true, preventing flicker during the loading window. The game screen uses `allFailed` to switch to the text fallback (base name, subtitle, epic action).
 
 ### Caching

--- a/src/components/imagePreview.tsx
+++ b/src/components/imagePreview.tsx
@@ -1,21 +1,50 @@
 import { Base } from '../hooks/useBases'
 
+const CARD_W = 1560
+const CARD_H = 1120
+
 interface ImagePreviewProps {
   base: Base
   src: string | null
   isHyperspace: boolean
   allFailed: boolean
   imageLoaded: boolean
+  rotationDeg: number
   useHyperspace: boolean
   onLoad: () => void
   onError: () => void
 }
 
-const imgStyle: React.CSSProperties = {
+const wrapperStyle: React.CSSProperties = {
   width: '100%',
+  aspectRatio: `${CARD_W} / ${CARD_H}`,
+  position: 'relative',
+  overflow: 'hidden',
   borderRadius: '12px',
   border: '2px solid #4fc3f7',
   boxShadow: '0 0 20px rgba(79, 195, 247, 0.3)',
+}
+
+const imgStyleNormal: React.CSSProperties = {
+  position: 'absolute',
+  inset: 0,
+  width: '100%',
+  height: '100%',
+  objectFit: 'cover',
+}
+
+// A portrait image (CARD_H × CARD_W) rotated 90° must fill a landscape box (CARD_W × CARD_H).
+// We size the layout box as (CARD_H/CARD_W × 100%) wide and (CARD_W/CARD_H × 100%) tall
+// — those are container-height-relative and container-width-relative percentages —
+// then center and rotate so the visual result is (100% × 100%) landscape fill.
+const imgStyleRotated: React.CSSProperties = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  width: `${100 * CARD_H / CARD_W}%`,   // layout portrait-width = container height
+  height: `${100 * CARD_W / CARD_H}%`,  // layout portrait-height = container width
+  objectFit: 'cover',
+  transform: 'translate(-50%, -50%) rotate(90deg)',
 }
 
 const messageStyle: React.CSSProperties = {
@@ -34,7 +63,7 @@ const errorStyle: React.CSSProperties = {
   fontStyle: 'italic',
 }
 
-function ImagePreview({ base, src, isHyperspace, allFailed, imageLoaded, useHyperspace, onLoad, onError }: ImagePreviewProps) {
+function ImagePreview({ base, src, isHyperspace, allFailed, imageLoaded, rotationDeg, useHyperspace, onLoad, onError }: ImagePreviewProps) {
   if (allFailed || !src) {
     return <p style={errorStyle}>No base images found</p>
   }
@@ -47,7 +76,15 @@ function ImagePreview({ base, src, isHyperspace, allFailed, imageLoaded, useHype
 
   return (
     <>
-      <img src={src} alt={base.name} onLoad={onLoad} onError={onError} style={imgStyle} />
+      <div style={{ ...wrapperStyle, visibility: imageLoaded ? 'visible' : 'hidden' }}>
+        <img
+          src={src}
+          alt={base.name}
+          onLoad={onLoad}
+          onError={onError}
+          style={rotationDeg ? imgStyleRotated : imgStyleNormal}
+        />
+      </div>
       {message && <p style={messageStyle}>{message}</p>}
     </>
   )

--- a/src/components/swuGameScreen.tsx
+++ b/src/components/swuGameScreen.tsx
@@ -78,6 +78,7 @@ function SwuGameScreen({ base, onBack, onHelp, useHyperspace }: Props) {
       onBack={onBack}
       onHelp={onHelp}
       imageSrc={art.src ?? ''}
+      imageRotationDeg={art.rotationDeg}
       count={count}
       imageLoaded={art.imageLoaded}
       imageError={art.allFailed}

--- a/src/components/swuGameScreenView.tsx
+++ b/src/components/swuGameScreenView.tsx
@@ -10,6 +10,7 @@ interface Props {
   onBack: () => void
   onHelp: () => void
   imageSrc: string
+  imageRotationDeg: number
   count: number
   imageLoaded: boolean
   imageError: boolean
@@ -24,6 +25,7 @@ function SwuGameScreenView({
   onBack,
   onHelp,
   imageSrc,
+  imageRotationDeg,
   count,
   imageLoaded,
   imageError,
@@ -133,11 +135,21 @@ function SwuGameScreenView({
           alt={base.name}
           onLoad={onImageLoad}
           onError={onImageError}
-          style={{
+          style={imageRotationDeg ? {
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            width: `${100 * CARD_NATURAL_HEIGHT / CARD_NATURAL_WIDTH}%`,
+            height: `${100 * CARD_NATURAL_WIDTH / CARD_NATURAL_HEIGHT}%`,
+            objectFit: 'cover',
+            transform: `translate(-50%, -50%) rotate(${imageRotationDeg}deg)`,
+            display: imageLoaded ? 'block' : 'none',
+          } : {
             position: 'absolute',
             inset: 0,
             width: '100%',
             height: '100%',
+            objectFit: 'cover',
             display: imageLoaded ? 'block' : 'none',
           }}
         />

--- a/src/components/swuSetupScreen.tsx
+++ b/src/components/swuSetupScreen.tsx
@@ -40,6 +40,7 @@ function SwuSetupScreen({ onConfirm, onHelp, initialSelection }: Props) {
       artIsHyperspace={art.isHyperspace}
       artAllFailed={art.allFailed}
       artImageLoaded={art.imageLoaded}
+      artRotationDeg={art.rotationDeg}
       onArtLoad={art.onLoad}
       onArtError={art.onError}
       onSetChange={setup.handleSetChange}

--- a/src/components/swuSetupScreenView.tsx
+++ b/src/components/swuSetupScreenView.tsx
@@ -18,6 +18,7 @@ interface Props {
   artIsHyperspace: boolean
   artAllFailed: boolean
   artImageLoaded: boolean
+  artRotationDeg: number
   onArtLoad: () => void
   onArtError: () => void
   onSetChange: (set: string) => void
@@ -62,6 +63,7 @@ function SwuSetupScreenView({
   artIsHyperspace,
   artAllFailed,
   artImageLoaded,
+  artRotationDeg,
   onArtLoad,
   onArtError,
   onSetChange,
@@ -295,6 +297,7 @@ function SwuSetupScreenView({
                   isHyperspace={artIsHyperspace}
                   allFailed={artAllFailed}
                   imageLoaded={artImageLoaded}
+                  rotationDeg={artRotationDeg}
                   useHyperspace={useHyperspace}
                   onLoad={onArtLoad}
                   onError={onArtError}

--- a/src/constants/rotatedCards.ts
+++ b/src/constants/rotatedCards.ts
@@ -1,0 +1,17 @@
+// Hi-res hyperspace images stored rotated on cdn.swu-db.com.
+// Keys are `${set}-${hyperspaceNumber}`. Value is degrees needed to correct display.
+export const ROTATED_HYPERSPACE_CARDS: Record<string, number> = {
+  'SOR-285': 90,  // Security Complex
+  'TWI-294': 90,  // Pau City
+  'TWI-297': 90,  // Droid Manufactory
+  'TWI-301': 90,  // KCM Mining Facility
+  'TWI-303': 90,  // Petranaki Arena
+}
+
+// Parses set and card number from a cdn.swu-db.com URL and returns the rotation
+// correction in degrees (0 if not in the lookup table or URL doesn't match).
+export function getRotationFromHyperspaceUrl(url: string): number {
+  const match = url.match(/\/cards\/([A-Z]+)\/(\d+)\.png/)
+  if (!match) return 0
+  return ROTATED_HYPERSPACE_CARDS[`${match[1]}-${match[2]}`] ?? 0
+}

--- a/src/hooks/useBaseArt.ts
+++ b/src/hooks/useBaseArt.ts
@@ -1,19 +1,25 @@
 import { useState, useMemo, useEffect } from 'react'
 import { Base } from './useBases'
+import { getRotationFromHyperspaceUrl } from '../constants/rotatedCards'
 
 interface ArtEntry {
   url: string
   isHyperspace: boolean
+  rotationDeg: number
 }
 
 function buildEntries(base: Base, useHyperspace: boolean): ArtEntry[] {
   const normal: ArtEntry[] = [
-    ...(base.frontArt ? [{ url: base.frontArt, isHyperspace: false }] : []),
-    ...(base.frontArtLowRes ? [{ url: base.frontArtLowRes, isHyperspace: false }] : []),
+    ...(base.frontArt ? [{ url: base.frontArt, isHyperspace: false, rotationDeg: 0 }] : []),
+    ...(base.frontArtLowRes ? [{ url: base.frontArtLowRes, isHyperspace: false, rotationDeg: 0 }] : []),
   ]
   const hyper: ArtEntry[] = [
-    ...(base.hyperspaceArtHiRes ? [{ url: base.hyperspaceArtHiRes, isHyperspace: true }] : []),
-    ...(base.hyperspaceArt ? [{ url: base.hyperspaceArt, isHyperspace: true }] : []),
+    ...(base.hyperspaceArtHiRes ? [{
+      url: base.hyperspaceArtHiRes,
+      isHyperspace: true,
+      rotationDeg: getRotationFromHyperspaceUrl(base.hyperspaceArtHiRes),
+    }] : []),
+    ...(base.hyperspaceArt ? [{ url: base.hyperspaceArt, isHyperspace: true, rotationDeg: 0 }] : []),
   ]
   return useHyperspace ? [...hyper, ...normal] : [...normal, ...hyper]
 }
@@ -30,7 +36,7 @@ export function useBaseArt(base: Base | null, useHyperspace: boolean) {
   useEffect(() => {
     setIndex(0)
     setImageLoaded(false)
-  }, [base?.set, base?.number])
+  }, [base?.set, base?.number, useHyperspace])
 
   const current = entries[index] ?? null
   const tried = entries.slice(0, index)
@@ -40,6 +46,7 @@ export function useBaseArt(base: Base | null, useHyperspace: boolean) {
   return {
     src: current?.url ?? null,
     isHyperspace: current?.isHyperspace ?? false,
+    rotationDeg: current?.rotationDeg ?? 0,
     allFailed: entries.length === 0 || index >= entries.length,
     normalFailed: normalCount > 0 && tried.filter(e => !e.isHyperspace).length >= normalCount,
     hyperspaceFailed: hyperCount > 0 && tried.filter(e => e.isHyperspace).length >= hyperCount,

--- a/src/test/useBaseArt.test.ts
+++ b/src/test/useBaseArt.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useBaseArt } from '../hooks/useBaseArt'
+import { getRotationFromHyperspaceUrl } from '../constants/rotatedCards'
 import { Base } from '../hooks/useBases'
 
 // All four art URLs present
@@ -40,6 +41,16 @@ const otherBase: Base = {
   hyperspaceArtHiRes: 'https://cdn/SOR/288.png',
   hyperspaceArt: null,
   epicAction: '', aspects: ['Cunning'], rarity: 'Rare',
+}
+
+// Known rotated card: SOR Security Complex, hyperspaceNumber 285
+const rotatedBase: Base = {
+  set: 'SOR', number: '019', name: 'Security Complex', subtitle: 'Scarif', hp: 30,
+  frontArt: 'https://cdn.swu-db.com/images/cards/SOR/019.png',
+  frontArtLowRes: null,
+  hyperspaceArtHiRes: 'https://cdn.swu-db.com/images/cards/SOR/285.png',
+  hyperspaceArt: null,
+  epicAction: '', aspects: ['Vigilance'], rarity: 'Common',
 }
 
 describe('useBaseArt', () => {
@@ -257,6 +268,85 @@ describe('useBaseArt', () => {
     currentBase = otherBase
     rerender()
     expect(result.current.imageLoaded).toBe(false)
+  })
+
+  // --- Reset on useHyperspace change ---
+
+  it('resets to first URL when useHyperspace changes', () => {
+    let hs = false
+    const { result, rerender } = renderHook(() => useBaseArt(fullBase, hs))
+    act(() => result.current.onError())
+    expect(result.current.src).toBe(fullBase.frontArtLowRes)
+    hs = true
+    rerender()
+    expect(result.current.src).toBe(fullBase.hyperspaceArtHiRes)
+  })
+
+  it('resets imageLoaded when useHyperspace changes', () => {
+    let hs = false
+    const { result, rerender } = renderHook(() => useBaseArt(fullBase, hs))
+    act(() => result.current.onLoad())
+    expect(result.current.imageLoaded).toBe(true)
+    hs = true
+    rerender()
+    expect(result.current.imageLoaded).toBe(false)
+  })
+
+    // --- Rotation correction ---
+
+  it('rotationDeg is 0 for a non-rotated base', () => {
+    const { result } = renderHook(() => useBaseArt(hyperspaceBase, true))
+    expect(result.current.rotationDeg).toBe(0)
+  })
+
+  it('rotationDeg is 90 for a known rotated hyperspace hi-res image', () => {
+    const { result } = renderHook(() => useBaseArt(rotatedBase, true))
+    expect(result.current.rotationDeg).toBe(90)
+  })
+
+  it('rotationDeg is 0 when showing the normal art of a rotated base', () => {
+    const { result } = renderHook(() => useBaseArt(rotatedBase, false))
+    expect(result.current.rotationDeg).toBe(0)
+  })
+
+  it('rotationDeg is 0 when rotated base falls back to normal art after hyperspace fails', () => {
+    const { result } = renderHook(() => useBaseArt(rotatedBase, true))
+    act(() => result.current.onError())
+    expect(result.current.rotationDeg).toBe(0)
+  })
+
+  it('rotationDeg is 0 when base is null', () => {
+    const { result } = renderHook(() => useBaseArt(null, false))
+    expect(result.current.rotationDeg).toBe(0)
+  })
+
+})
+
+describe('getRotationFromHyperspaceUrl', () => {
+
+  it('returns 90 for a known rotated card URL', () => {
+    expect(getRotationFromHyperspaceUrl('https://cdn.swu-db.com/images/cards/SOR/285.png')).toBe(90)
+  })
+
+  it('returns 0 for a non-rotated card URL', () => {
+    expect(getRotationFromHyperspaceUrl('https://cdn.swu-db.com/images/cards/SOR/292.png')).toBe(0)
+  })
+
+  it('returns 0 for a non-cdn URL (swuapi fallback)', () => {
+    expect(getRotationFromHyperspaceUrl('https://swuapi.com/some-card.png')).toBe(0)
+  })
+
+  it('returns 90 for all five known rotated cards', () => {
+    const rotated = [
+      'https://cdn.swu-db.com/images/cards/SOR/285.png',
+      'https://cdn.swu-db.com/images/cards/TWI/294.png',
+      'https://cdn.swu-db.com/images/cards/TWI/297.png',
+      'https://cdn.swu-db.com/images/cards/TWI/301.png',
+      'https://cdn.swu-db.com/images/cards/TWI/303.png',
+    ]
+    for (const url of rotated) {
+      expect(getRotationFromHyperspaceUrl(url)).toBe(90)
+    }
   })
 
 })


### PR DESCRIPTION
Introduces a capability that rotates images that have been loaded in portrait rather than landscape, and ensures rotation isn't visible to the user when switching between normal and hyperspace art

Closes #42 