### PR TITLE
chore: add PR trigger and deploy guard to workflow for branch protection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   test:
@@ -43,6 +45,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       pages: write


### PR DESCRIPTION
## Summary
- Adds `pull_request` trigger so CI runs on PRs (not just pushes to main)
- Guards the `deploy` job with `if: github.event_name == 'push'` so deploys only happen on merge to main

## Test plan
- [x] CI (test + build) runs on this PR
- [x] Deploy job is skipped on this PR
- [x] Close #37 after merge

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)