### PR TITLE
bug/low-res-previews 

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,7 +76,7 @@ App
 │   ├── useBaseArt        (hook — ordered art fallback chain, image load state)
 │   ├── useWakeLock       (hook — prevents screen sleep during gameplay via Screen Wake Lock API)
 │   ├── useGameLog        (hook — ordered list of game log entries with add/undo/reset; each entry records event type, message, colour, and previous game state snapshot)
-│   ├── GameLogOverlay    (view — scrollable log panel; auto-scrolls to latest entry; undo button on last undoable entry)
+│   ├── GameLogOverlay    (view — scrollable log panel; auto-scrolls to latest entry; undo button on last undoable entry; round entries styled with blue gradient)
 │   └── SwuGameScreenView (view — renders counter, image, epic action token, Force token; ⚙ button always visible; calls useDragScrubber directly for drag-to-scrub gesture state)
 ├── SwuHelpScreen         (standalone screen — renders help.md content)
 └── SwuSettingsScreen     (container)
@@ -135,7 +135,7 @@ src/
     swuSettingsScreenView.tsx Settings screen view (toggle list; calls useOrientation directly for iOS font sizing)
 
   hooks/
-    useBaseArt.ts           Ordered art fallback chain shared by setup and game screens; `preview` param (default `false`) puts low-res URLs first — setup screen passes `true`, game screen uses default. Exports `getFirstGameImageUrl(base, useHyperspace)` which returns the first URL from the game-mode chain, used by the setup screen to preload the game image while the user is still on the setup screen
+    useBaseArt.ts           Ordered art fallback chain shared by setup and game screens. Exports `getFirstGameImageUrl(base, useHyperspace)` which returns the first URL from the fallback chain, used by the setup screen to preload the game image while the user is still on the setup screen
     useDragScrubber.ts      Drag-to-scrub gesture — tracks pointer events on `+`/`−` counter buttons; exposes `dragIndicator` (type, value, clientX, clientY) and pointer event handlers; 15px dead zone before scrub activates; 14px per step; caps drag value at `Math.min(max, 20)`; suppresses synthetic click after drag; disabled when `enableLongPress` is false or the reachable cap is < 2
     useBases.ts             Fetches and caches the full list of Base cards
     useFavourites.ts        Favourites list — add/remove/clear operations with deduplication on key; sorted by set then card number ascending; persists FavouriteBase[] to localStorage under key `favourites`; UI gated by enableFavourites in useUserSettings (tickets #123, #124 complete)
@@ -358,26 +358,14 @@ The `Base` interface captures all four possible art sources: `frontArt`, `frontA
 
 #### Art fallback chain (`useBaseArt`)
 
-Both the setup screen and the game screen call `useBaseArt(base, useHyperspace, preview)`, which builds an ordered URL list (filtering out `null` entries) and maintains a fallback index. On each `onError` the index advances; `allFailed` only becomes `true` once all URLs are exhausted. The hook also tracks `imageLoaded`, `normalFailed`, and `hyperspaceFailed` so callers can derive UI state without re-inspecting the base object.
+Both the setup screen and the game screen call `useBaseArt(base, useHyperspace)`, which builds an ordered URL list (filtering out `null` entries) and maintains a fallback index. On each `onError` the index advances; `allFailed` only becomes `true` once all URLs are exhausted. The hook also tracks `imageLoaded`, `normalFailed`, and `hyperspaceFailed` so callers can derive UI state without re-inspecting the base object.
 
-The `preview` flag (default `false`) reorders the within-group art priority to prefer low-res URLs first. The setup screen passes `preview = true` to minimise LCP; the game screen uses the default `false` to prefer hi-res.
-
-**Setup screen (preview = true) — hyperspace preferred:**
-```
-hyperspaceArt → hyperspaceArtHiRes → frontArtLowRes → frontArt → text/error
-```
-
-**Setup screen (preview = true) — normal preferred:**
-```
-frontArtLowRes → frontArt → hyperspaceArt → hyperspaceArtHiRes → text/error
-```
-
-**Game screen (preview = false) — hyperspace preferred:**
+**Hyperspace preferred:**
 ```
 hyperspaceArtHiRes → hyperspaceArt → frontArt → frontArtLowRes → text/error
 ```
 
-**Game screen (preview = false) — normal preferred:**
+**Normal preferred:**
 ```
 frontArt → frontArtLowRes → hyperspaceArtHiRes → hyperspaceArt → text/error
 ```
@@ -847,6 +835,3 @@ The app targets mobile browsers and PWA installation. Key performance constraint
 | **Screen Wake Lock** | A browser API (`navigator.wakeLock.request('screen')`) that prevents the device screen from sleeping. Used by `useWakeLock` on the game screen when `enableWakeLock` is true in user settings. Supported on Android Chrome and iOS Safari PWA (iOS 16.4+). |
 | **swu-db proxy** | A Cloudflare Worker at `swu-proxy.dmgctrl.workers.dev` that proxies requests to swu-db.com and swudb.com to avoid CORS issues. |
 | **PWA** | Progressive Web App — a web app that can be installed on a device and used offline. |
-| **SOR** | Spark of Rebellion — the first set of Star Wars Unlimited cards. |
-| **LAW** | Legends of the Alliance — a later set of Star Wars Unlimited cards. |
-| **SWUDB** | swudb.com — a third-party Star Wars Unlimited database site. Deck lists can be imported via a URL of the form `https://swudb.com/deck/<id>`. |

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -104,7 +104,7 @@ Timing can be adjusted via `VISUAL_PAUSE_MS` at the top of the script.
 | Metric | What it measures |
 |---|---|
 | **Setup ready** | Navigation start → set selector enabled (covers loading screen + base data fetch) |
-| **Preview image** | First base selected → card image visible in setup screen (the #142 metric — low-res-first fallback chain) |
+| **Preview image** | First base selected → card image visible in setup screen |
 | **Game (low res)** | Start clicked → card image visible — TS26 base (`frontArtLowRes` only, no CDN art) |
 | **Game (normal res)** | Start clicked → card image visible — LAW-021 (`frontArt` from CDN) |
 | **Game (hi res)** | Start clicked → card image visible — SOR-019 with hyperspace on (`hyperspaceArtHiRes` / SOR-285) |

--- a/src/components/swuSetupScreen.tsx
+++ b/src/components/swuSetupScreen.tsx
@@ -20,7 +20,7 @@ function SwuSetupScreen({ onConfirm, onHelp, onSettings, initialSelection }: Pro
   const { useHyperspace, enableFavourites } = useUserSettings()
   const { favourites, addFavourite, removeFavourite } = useFavourites()
   const setup = useSwuSetup(onConfirm, initialSelection)
-  const art = useBaseArt(setup.selectedBase, useHyperspace, true)
+  const art = useBaseArt(setup.selectedBase, useHyperspace)
 
   useEffect(() => {
     const url = getFirstGameImageUrl(setup.selectedBase, useHyperspace)

--- a/src/hooks/useBaseArt.ts
+++ b/src/hooks/useBaseArt.ts
@@ -8,48 +8,34 @@ interface ArtEntry {
   rotationDeg: number
 }
 
-function buildEntries(base: Base, useHyperspace: boolean, preview: boolean): ArtEntry[] {
-  const normal: ArtEntry[] = preview
-    ? [
-        ...(base.frontArtLowRes ? [{ url: base.frontArtLowRes, isHyperspace: false, rotationDeg: 0 }] : []),
-        ...(base.frontArt ? [{ url: base.frontArt, isHyperspace: false, rotationDeg: 0 }] : []),
-      ]
-    : [
-        ...(base.frontArt ? [{ url: base.frontArt, isHyperspace: false, rotationDeg: 0 }] : []),
-        ...(base.frontArtLowRes ? [{ url: base.frontArtLowRes, isHyperspace: false, rotationDeg: 0 }] : []),
-      ]
-  const hyper: ArtEntry[] = preview
-    ? [
-        ...(base.hyperspaceArt ? [{ url: base.hyperspaceArt, isHyperspace: true, rotationDeg: 0 }] : []),
-        ...(base.hyperspaceArtHiRes ? [{
-          url: base.hyperspaceArtHiRes,
-          isHyperspace: true,
-          rotationDeg: getRotationFromHyperspaceUrl(base.hyperspaceArtHiRes),
-        }] : []),
-      ]
-    : [
-        ...(base.hyperspaceArtHiRes ? [{
-          url: base.hyperspaceArtHiRes,
-          isHyperspace: true,
-          rotationDeg: getRotationFromHyperspaceUrl(base.hyperspaceArtHiRes),
-        }] : []),
-        ...(base.hyperspaceArt ? [{ url: base.hyperspaceArt, isHyperspace: true, rotationDeg: 0 }] : []),
-      ]
+function buildEntries(base: Base, useHyperspace: boolean): ArtEntry[] {
+  const normal: ArtEntry[] = [
+    ...(base.frontArt ? [{ url: base.frontArt, isHyperspace: false, rotationDeg: 0 }] : []),
+    ...(base.frontArtLowRes ? [{ url: base.frontArtLowRes, isHyperspace: false, rotationDeg: 0 }] : []),
+  ]
+  const hyper: ArtEntry[] = [
+    ...(base.hyperspaceArtHiRes ? [{
+      url: base.hyperspaceArtHiRes,
+      isHyperspace: true,
+      rotationDeg: getRotationFromHyperspaceUrl(base.hyperspaceArtHiRes),
+    }] : []),
+    ...(base.hyperspaceArt ? [{ url: base.hyperspaceArt, isHyperspace: true, rotationDeg: 0 }] : []),
+  ]
   return useHyperspace ? [...hyper, ...normal] : [...normal, ...hyper]
 }
 
 export function getFirstGameImageUrl(base: Base | null, useHyperspace: boolean): string | null {
   if (!base) return null
-  return buildEntries(base, useHyperspace, false)[0]?.url ?? null
+  return buildEntries(base, useHyperspace)[0]?.url ?? null
 }
 
-export function useBaseArt(base: Base | null, useHyperspace: boolean, preview = false) {
+export function useBaseArt(base: Base | null, useHyperspace: boolean) {
   const [index, setIndex] = useState(0)
   const [imageLoaded, setImageLoaded] = useState(false)
 
   const entries = useMemo(
-    () => (base ? buildEntries(base, useHyperspace, preview) : []),
-    [base, useHyperspace, preview],
+    () => (base ? buildEntries(base, useHyperspace) : []),
+    [base, useHyperspace],
   )
 
   useEffect(() => {

--- a/src/test/useBaseArt.test.ts
+++ b/src/test/useBaseArt.test.ts
@@ -181,66 +181,6 @@ describe('useBaseArt', () => {
     expect(result.current.allFailed).toBe(true)
   })
 
-  // --- Preview mode: normal preferred ---
-
-  it('src is frontArtLowRes initially in preview mode (normal preferred)', () => {
-    const { result } = renderHook(() => useBaseArt(fullBase, false, true))
-    expect(result.current.src).toBe(fullBase.frontArtLowRes)
-  })
-
-  it('advances to frontArt after one error in preview mode (normal preferred)', () => {
-    const { result } = renderHook(() => useBaseArt(fullBase, false, true))
-    act(() => result.current.onError())
-    expect(result.current.src).toBe(fullBase.frontArt)
-  })
-
-  it('advances to hyperspaceArt after two errors in preview mode (normal preferred)', () => {
-    const { result } = renderHook(() => useBaseArt(fullBase, false, true))
-    act(() => result.current.onError())
-    act(() => result.current.onError())
-    expect(result.current.src).toBe(fullBase.hyperspaceArt)
-  })
-
-  it('advances to hyperspaceArtHiRes after three errors in preview mode (normal preferred)', () => {
-    const { result } = renderHook(() => useBaseArt(fullBase, false, true))
-    act(() => result.current.onError())
-    act(() => result.current.onError())
-    act(() => result.current.onError())
-    expect(result.current.src).toBe(fullBase.hyperspaceArtHiRes)
-  })
-
-  it('src is frontArt initially in preview mode when no frontArtLowRes exists', () => {
-    const { result } = renderHook(() => useBaseArt(sparseBase, false, true))
-    expect(result.current.src).toBe(sparseBase.frontArt)
-  })
-
-  // --- Preview mode: hyperspace preferred ---
-
-  it('src is hyperspaceArt initially in preview mode (hyperspace preferred)', () => {
-    const { result } = renderHook(() => useBaseArt(fullBase, true, true))
-    expect(result.current.src).toBe(fullBase.hyperspaceArt)
-  })
-
-  it('advances to hyperspaceArtHiRes after one error in preview mode (hyperspace preferred)', () => {
-    const { result } = renderHook(() => useBaseArt(fullBase, true, true))
-    act(() => result.current.onError())
-    expect(result.current.src).toBe(fullBase.hyperspaceArtHiRes)
-  })
-
-  it('advances to frontArtLowRes after two errors in preview mode (hyperspace preferred)', () => {
-    const { result } = renderHook(() => useBaseArt(fullBase, true, true))
-    act(() => result.current.onError())
-    act(() => result.current.onError())
-    expect(result.current.src).toBe(fullBase.frontArtLowRes)
-  })
-
-  it('advances to frontArt after three errors in preview mode (hyperspace preferred)', () => {
-    const { result } = renderHook(() => useBaseArt(fullBase, true, true))
-    act(() => result.current.onError())
-    act(() => result.current.onError())
-    act(() => result.current.onError())
-    expect(result.current.src).toBe(fullBase.frontArt)
-  })
 
   // --- isHyperspace transitions ---
 


### PR DESCRIPTION
reverts the change to use lower resolution images for previews as the UX of lower resolution is worse than the benefit of faster load times

Closes #156 