### PR TITLE
feat/tournament-data-foundation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { Base, useBases } from './hooks/useBases'
 import { InitialSelection } from './hooks/useSwuSetup'
 import { useUserSettings } from './hooks/useUserSettings'
 import { onAppStart, onGameStart, onGameEnd, onAppInstall, onAppResume } from './services/analytics'
-import type { PlayMode } from './utils/playMode'
+import type { PlayMode, SetupMode } from './utils/playMode'
 
 type Screen = 'loading' | 'setup' | 'game' | 'help' | 'settings'
 
@@ -55,14 +55,18 @@ function App() {
 
   const handleReady = () => setScreen('setup')
 
-  const handleConfirm = (base: Base, playMode: PlayMode) => {
+  const handleConfirm = (base: Base, mode: SetupMode) => {
+    if (mode === 'tournament') {
+      // Tournament screen wired in #205
+      return
+    }
     setSelectedBase(base)
-    setSelectedPlayMode(playMode)
+    setSelectedPlayMode('casual')
     setLastSelection({ set: base.set, aspect: base.aspects[0] ?? 'None', key: `${base.set}-${base.number}` })
     setIsInGame(true)
     setScreen('game')
     gameStartTime.current = Date.now()
-    void onGameStart(`${base.set}-${base.number}`, base.set, useHyperspace, playMode)
+    void onGameStart(`${base.set}-${base.number}`, base.set, useHyperspace, 'casual')
   }
 
   const handleBack = () => {

--- a/src/components/swuSettingsScreenView.tsx
+++ b/src/components/swuSettingsScreenView.tsx
@@ -256,7 +256,7 @@ function SwuSettingsScreenView({
       <ToggleRow
         id="toggle-competitive-mode"
         label="Enable Competitive Mode"
-        subtitle="Adds a play mode selector (Casual / Best of 1 / Best of 3) to the setup screen."
+        subtitle="Beta feature. Adds a tournament mode selector to the setup screen."
         checked={enableCompetitiveMode}
         onChange={onEnableCompetitiveModeChange}
         vmin={vmin}

--- a/src/components/swuSetupScreen.tsx
+++ b/src/components/swuSetupScreen.tsx
@@ -8,12 +8,12 @@ import { useFavourites } from '../hooks/useFavourites'
 import { normaliseSwudbUrl, isValidSwudbUrl, fetchSwudbDeck } from '../utils/swudbUrl'
 import { onFavouriteAdded, onFavouriteRemoved, onDeckImportSuccess, onDeckImportFailure } from '../services/analytics'
 import { isBaseValidForFormat, isSetValidForFormat, formatValidationError } from '../utils/formatFilter'
-import { PlayMode } from '../utils/playMode'
+import { SetupMode } from '../utils/playMode'
 
 export type SelectionMode = 'base-selector' | 'swudb-import' | 'favourites'
 
 interface Props {
-  onConfirm: (base: Base, playMode: PlayMode) => void
+  onConfirm: (base: Base, mode: SetupMode) => void
   onHelp: () => void
   onSettings?: () => void
   initialSelection?: InitialSelection | null
@@ -147,8 +147,8 @@ function SwuSetupScreen({ onConfirm, onHelp, onSettings, initialSelection }: Pro
       selectedFormat={setup.selectedFormat}
       onFormatChange={setup.handleFormatChange}
       enableCompetitiveMode={enableCompetitiveMode}
-      selectedPlayMode={setup.selectedPlayMode}
-      onPlayModeChange={setup.handlePlayModeChange}
+      selectedSetupMode={setup.selectedMode}
+      onSetupModeChange={setup.handleModeChange}
       availableSets={setup.validSets}
       availableAspects={setup.availableAspects}
       filteredBases={setup.filteredBases}

--- a/src/components/swuSetupScreenView.tsx
+++ b/src/components/swuSetupScreenView.tsx
@@ -6,7 +6,7 @@ import { CogIcon, ForwardIcon, HelpIcon } from './icons'
 import { SelectionMode } from './swuSetupScreen'
 import type { FavouriteBase } from '../hooks/useFavourites'
 import { Format, FORMATS, FORMAT_LABELS } from '../utils/formatFilter'
-import { PlayMode, PLAY_MODES, PLAY_MODE_LABELS } from '../utils/playMode'
+import { SetupMode, SETUP_MODES, SETUP_MODE_LABELS } from '../utils/playMode'
 
 interface Props {
   loading: boolean
@@ -14,8 +14,8 @@ interface Props {
   selectedFormat: Format
   onFormatChange: (format: Format) => void
   enableCompetitiveMode: boolean
-  selectedPlayMode: PlayMode
-  onPlayModeChange: (mode: PlayMode) => void
+  selectedSetupMode: SetupMode
+  onSetupModeChange: (mode: SetupMode) => void
   availableSets: string[]
   availableAspects: string[]
   filteredBases: Base[]
@@ -191,23 +191,23 @@ function FormatSelector({ selectedFormat, onFormatChange, small = false }: {
   )
 }
 
-function PlayModeSelector({ selectedPlayMode, onPlayModeChange, small = false }: {
-  selectedPlayMode: PlayMode
-  onPlayModeChange: (mode: PlayMode) => void
+function SetupModeSelector({ selectedSetupMode, onSetupModeChange, small = false }: {
+  selectedSetupMode: SetupMode
+  onSetupModeChange: (mode: SetupMode) => void
   small?: boolean
 }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '1vw' }}>
       <label style={labelStyle(small)}>Match:</label>
       <select
-        value={selectedPlayMode}
-        onChange={e => onPlayModeChange(e.target.value as PlayMode)}
+        value={selectedSetupMode}
+        onChange={e => onSetupModeChange(e.target.value as SetupMode)}
         data-testid="play-mode-select"
         style={selectStyle(true, true, small)}
       >
-        {PLAY_MODES.map(m => (
+        {SETUP_MODES.map(m => (
           <option key={m} value={m} style={{ color: 'var(--color-text-primary)', background: 'var(--color-bg-deep)' }}>
-            {PLAY_MODE_LABELS[m]}
+            {SETUP_MODE_LABELS[m]}
           </option>
         ))}
       </select>
@@ -221,8 +221,8 @@ function SwuSetupScreenView({
   selectedFormat,
   onFormatChange,
   enableCompetitiveMode,
-  selectedPlayMode,
-  onPlayModeChange,
+  selectedSetupMode,
+  onSetupModeChange,
   availableSets,
   availableAspects,
   filteredBases,
@@ -677,7 +677,7 @@ function SwuSetupScreenView({
                 </div>
                 {enableCompetitiveMode && (
                   <div style={{ flex: 1, minWidth: 0 }}>
-                    <PlayModeSelector selectedPlayMode={selectedPlayMode} onPlayModeChange={onPlayModeChange} small />
+                    <SetupModeSelector selectedSetupMode={selectedSetupMode} onSetupModeChange={onSetupModeChange} small />
                   </div>
                 )}
               </div>
@@ -815,7 +815,7 @@ function SwuSetupScreenView({
           </div>
           {enableCompetitiveMode && (
             <div style={{ flex: 1, minWidth: 0 }}>
-              <PlayModeSelector selectedPlayMode={selectedPlayMode} onPlayModeChange={onPlayModeChange} />
+              <SetupModeSelector selectedSetupMode={selectedSetupMode} onSetupModeChange={onSetupModeChange} />
             </div>
           )}
         </div>

--- a/src/hooks/useSwuSetup.ts
+++ b/src/hooks/useSwuSetup.ts
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect } from 'react'
 import { useBases, Base } from './useBases'
 import { Format, getValidSets } from '../utils/formatFilter'
-import { PlayMode } from '../utils/playMode'
+import { SetupMode } from '../utils/playMode'
 
 const ASPECT_ORDER = ['Vigilance', 'Command', 'Aggression', 'Cunning', 'None']
 
@@ -12,7 +12,7 @@ export interface InitialSelection {
 }
 
 export function useSwuSetup(
-  onConfirm: (base: Base, playMode: PlayMode) => void,
+  onConfirm: (base: Base, mode: SetupMode) => void,
   initialSelection?: InitialSelection | null,
 ) {
   const { bases, loading, error } = useBases()
@@ -28,9 +28,10 @@ export function useSwuSetup(
     return 'premier'
   })
 
-  const [selectedPlayMode, setSelectedPlayMode] = useState<PlayMode>(() => {
+  const [selectedMode, setSelectedMode] = useState<SetupMode>(() => {
     const saved = localStorage.getItem('pref_play_mode')
-    if (saved === 'bo1' || saved === 'bo3') return saved
+    if (saved === 'tournament') return 'tournament'
+    if (saved === 'bo1' || saved === 'bo3') return 'tournament'
     return 'casual'
   })
 
@@ -86,8 +87,8 @@ export function useSwuSetup(
     }
   }, [filteredBases])
 
-  const handlePlayModeChange = (mode: PlayMode) => {
-    setSelectedPlayMode(mode)
+  const handleModeChange = (mode: SetupMode) => {
+    setSelectedMode(mode)
     localStorage.setItem('pref_play_mode', mode)
   }
 
@@ -120,7 +121,7 @@ export function useSwuSetup(
 
   const handleSubmit = () => {
     if (!selectedBase) return
-    onConfirm(selectedBase, selectedPlayMode)
+    onConfirm(selectedBase, selectedMode)
   }
 
   const selectBaseByKey = (key: string): boolean => {
@@ -137,7 +138,7 @@ export function useSwuSetup(
     loading,
     error,
     selectedFormat,
-    selectedPlayMode,
+    selectedMode,
     selectedSet,
     selectedAspect,
     selectedKey,
@@ -147,7 +148,7 @@ export function useSwuSetup(
     availableAspects,
     filteredBases,
     handleFormatChange,
-    handlePlayModeChange,
+    handleModeChange,
     handleSetChange,
     handleAspectChange,
     handleKeyChange,

--- a/src/hooks/useTournament.ts
+++ b/src/hooks/useTournament.ts
@@ -1,0 +1,133 @@
+import { useState } from 'react'
+import type { Dispatch, SetStateAction } from 'react'
+import type { Base } from './useBases'
+import type { Format } from '../utils/formatFilter'
+
+const STORAGE_KEY = 'tournament_state'
+
+export interface TournamentRound {
+  roundNumber: number
+  playerScore: number
+  opponentScore: number
+  result: 'won' | 'lost' | 'drawn' | null
+  submitted: boolean
+}
+
+export interface TournamentState {
+  base: Base
+  format: Format
+  tournamentId: string
+  playMode: 'bo1' | 'bo3'
+  totalRounds: number
+  rounds: TournamentRound[]
+}
+
+function load(): TournamentState | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    return JSON.parse(raw) as TournamentState
+  } catch {
+    return null
+  }
+}
+
+function persist(state: TournamentState): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+}
+
+function update(
+  setState: Dispatch<SetStateAction<TournamentState | null>>,
+  next: TournamentState,
+): void {
+  persist(next)
+  setState(next)
+}
+
+export function useTournament() {
+  const [tournament, setTournament] = useState<TournamentState | null>(load)
+
+  const matchInProgress =
+    tournament !== null &&
+    tournament.rounds.length > 0 &&
+    tournament.rounds[tournament.rounds.length - 1].result === null
+
+  const isComplete =
+    tournament !== null &&
+    tournament.rounds.length === tournament.totalRounds &&
+    tournament.rounds.every(r => r.result !== null)
+
+  const totals = (tournament?.rounds ?? []).reduce(
+    (acc, r) => {
+      if (r.result === 'won') acc.won++
+      else if (r.result === 'lost') acc.lost++
+      else if (r.result === 'drawn') acc.drawn++
+      return acc
+    },
+    { won: 0, lost: 0, drawn: 0 },
+  )
+
+  const startTournament = (
+    base: Base,
+    format: Format,
+    tournamentId: string,
+    playMode: 'bo1' | 'bo3',
+    totalRounds: number,
+  ) => {
+    const next: TournamentState = { base, format, tournamentId, playMode, totalRounds, rounds: [] }
+    update(setTournament, next)
+  }
+
+  const startMatch = () => {
+    if (!tournament || matchInProgress) return
+    const round: TournamentRound = {
+      roundNumber: tournament.rounds.length + 1,
+      playerScore: 0,
+      opponentScore: 0,
+      result: null,
+      submitted: false,
+    }
+    update(setTournament, { ...tournament, rounds: [...tournament.rounds, round] })
+  }
+
+  const completeMatch = (result: 'won' | 'lost' | 'drawn', playerScore: number, opponentScore: number) => {
+    if (!tournament || !matchInProgress) return
+    const rounds = tournament.rounds.map((r, i) =>
+      i === tournament.rounds.length - 1 ? { ...r, result, playerScore, opponentScore } : r,
+    )
+    update(setTournament, { ...tournament, rounds })
+  }
+
+  const submitRound = () => {
+    if (!tournament) return
+    const last = tournament.rounds[tournament.rounds.length - 1]
+    if (!last || last.result === null) return
+    const rounds = tournament.rounds.map((r, i) =>
+      i === tournament.rounds.length - 1 ? { ...r, submitted: true } : r,
+    )
+    update(setTournament, { ...tournament, rounds })
+  }
+
+  const dropTournament = () => {
+    localStorage.removeItem(STORAGE_KEY)
+    setTournament(null)
+  }
+
+  const setTournamentId = (id: string) => {
+    if (!tournament) return
+    update(setTournament, { ...tournament, tournamentId: id })
+  }
+
+  return {
+    tournament,
+    matchInProgress,
+    isComplete,
+    totals,
+    startTournament,
+    startMatch,
+    completeMatch,
+    submitRound,
+    dropTournament,
+    setTournamentId,
+  }
+}

--- a/src/test/swuSetupScreen.test.tsx
+++ b/src/test/swuSetupScreen.test.tsx
@@ -1331,15 +1331,14 @@ describe('SwuSetupScreen — play mode selector', () => {
     await waitFor(() => expect(screen.getByTestId('play-mode-select')).toBeInTheDocument())
   })
 
-  it('play mode selector has Casual, Bo1 and Bo3 options', async () => {
+  it('play mode selector has Casual and Tournament options', async () => {
     mockUserSettings.enableCompetitiveMode = true
     render(<SwuSetupScreen onConfirm={vi.fn()} onHelp={vi.fn()} />)
     await waitFor(() => expect(screen.getByTestId('play-mode-select')).toBeInTheDocument())
     const select = screen.getByTestId('play-mode-select') as HTMLSelectElement
     const options = Array.from(select.options).map(o => o.value)
     expect(options).toContain('casual')
-    expect(options).toContain('bo1')
-    expect(options).toContain('bo3')
+    expect(options).toContain('tournament')
   })
 
   it('play mode selector defaults to casual', async () => {
@@ -1349,18 +1348,18 @@ describe('SwuSetupScreen — play mode selector', () => {
     expect((screen.getByTestId('play-mode-select') as HTMLSelectElement).value).toBe('casual')
   })
 
-  it('onConfirm is called with the selected play mode', async () => {
+  it('onConfirm is called with tournament mode when tournament is selected', async () => {
     mockUserSettings.enableCompetitiveMode = true
     const user = userEvent.setup()
     const onConfirm = vi.fn()
     render(<SwuSetupScreen onConfirm={onConfirm} onHelp={vi.fn()} />)
     await waitFor(() => expect(screen.getByTestId('play-mode-select')).toBeInTheDocument())
-    await user.selectOptions(screen.getByTestId('play-mode-select'), 'bo3')
+    await user.selectOptions(screen.getByTestId('play-mode-select'), 'tournament')
     await waitFor(() => expect(screen.getAllByRole('combobox').slice(3)).toHaveLength(3))
     await user.selectOptions(screen.getAllByRole('combobox').slice(3)[0], 'JTL')
     await waitFor(() => expect(screen.getByRole('button', { name: 'Start game' })).not.toBeDisabled())
     await user.click(screen.getByRole('button', { name: 'Start game' }))
-    expect(onConfirm).toHaveBeenCalledWith(expect.objectContaining({ set: 'JTL' }), 'bo3')
+    expect(onConfirm).toHaveBeenCalledWith(expect.objectContaining({ set: 'JTL' }), 'tournament')
   })
 
 })

--- a/src/test/useSwuSetup.test.ts
+++ b/src/test/useSwuSetup.test.ts
@@ -431,43 +431,17 @@ describe('useSwuSetup', () => {
 
 })
 
-// ---------- play mode ----------
+// ---------- setup mode ----------
 
-describe('useSwuSetup — play mode', () => {
+describe('useSwuSetup — setup mode', () => {
 
-  it('selectedPlayMode defaults to casual when storage is empty', () => {
+  it('selectedMode defaults to casual when storage is empty', () => {
     vi.mocked(useBases).mockReturnValue({ bases: mockBases, loading: false, error: null })
     const { result } = renderHook(() => useSwuSetup(vi.fn()))
-    expect(result.current.selectedPlayMode).toBe('casual')
+    expect(result.current.selectedMode).toBe('casual')
   })
 
-  it('selectedPlayMode loads bo1 from localStorage', () => {
-    vi.stubGlobal('localStorage', {
-      getItem: vi.fn((key: string) => key === 'pref_play_mode' ? 'bo1' : null),
-      setItem: vi.fn(),
-      removeItem: vi.fn(),
-      clear: vi.fn(),
-    })
-    vi.mocked(useBases).mockReturnValue({ bases: mockBases, loading: false, error: null })
-    const { result } = renderHook(() => useSwuSetup(vi.fn()))
-    expect(result.current.selectedPlayMode).toBe('bo1')
-    vi.unstubAllGlobals()
-  })
-
-  it('selectedPlayMode loads bo3 from localStorage', () => {
-    vi.stubGlobal('localStorage', {
-      getItem: vi.fn((key: string) => key === 'pref_play_mode' ? 'bo3' : null),
-      setItem: vi.fn(),
-      removeItem: vi.fn(),
-      clear: vi.fn(),
-    })
-    vi.mocked(useBases).mockReturnValue({ bases: mockBases, loading: false, error: null })
-    const { result } = renderHook(() => useSwuSetup(vi.fn()))
-    expect(result.current.selectedPlayMode).toBe('bo3')
-    vi.unstubAllGlobals()
-  })
-
-  it('selectedPlayMode falls back to casual for an unknown value in localStorage', () => {
+  it('selectedMode loads tournament from localStorage', () => {
     vi.stubGlobal('localStorage', {
       getItem: vi.fn((key: string) => key === 'pref_play_mode' ? 'tournament' : null),
       setItem: vi.fn(),
@@ -476,18 +450,57 @@ describe('useSwuSetup — play mode', () => {
     })
     vi.mocked(useBases).mockReturnValue({ bases: mockBases, loading: false, error: null })
     const { result } = renderHook(() => useSwuSetup(vi.fn()))
-    expect(result.current.selectedPlayMode).toBe('casual')
+    expect(result.current.selectedMode).toBe('tournament')
     vi.unstubAllGlobals()
   })
 
-  it('handlePlayModeChange updates selectedPlayMode', () => {
+  it('selectedMode migrates bo1 from localStorage to tournament', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn((key: string) => key === 'pref_play_mode' ? 'bo1' : null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    })
     vi.mocked(useBases).mockReturnValue({ bases: mockBases, loading: false, error: null })
     const { result } = renderHook(() => useSwuSetup(vi.fn()))
-    act(() => result.current.handlePlayModeChange('bo3'))
-    expect(result.current.selectedPlayMode).toBe('bo3')
+    expect(result.current.selectedMode).toBe('tournament')
+    vi.unstubAllGlobals()
   })
 
-  it('handlePlayModeChange persists to localStorage', () => {
+  it('selectedMode migrates bo3 from localStorage to tournament', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn((key: string) => key === 'pref_play_mode' ? 'bo3' : null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    })
+    vi.mocked(useBases).mockReturnValue({ bases: mockBases, loading: false, error: null })
+    const { result } = renderHook(() => useSwuSetup(vi.fn()))
+    expect(result.current.selectedMode).toBe('tournament')
+    vi.unstubAllGlobals()
+  })
+
+  it('selectedMode falls back to casual for an unknown value in localStorage', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn((key: string) => key === 'pref_play_mode' ? 'unknown' : null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    })
+    vi.mocked(useBases).mockReturnValue({ bases: mockBases, loading: false, error: null })
+    const { result } = renderHook(() => useSwuSetup(vi.fn()))
+    expect(result.current.selectedMode).toBe('casual')
+    vi.unstubAllGlobals()
+  })
+
+  it('handleModeChange updates selectedMode', () => {
+    vi.mocked(useBases).mockReturnValue({ bases: mockBases, loading: false, error: null })
+    const { result } = renderHook(() => useSwuSetup(vi.fn()))
+    act(() => result.current.handleModeChange('tournament'))
+    expect(result.current.selectedMode).toBe('tournament')
+  })
+
+  it('handleModeChange persists to localStorage', () => {
     const setItem = vi.fn()
     vi.stubGlobal('localStorage', {
       getItem: vi.fn().mockReturnValue(null),
@@ -497,9 +510,21 @@ describe('useSwuSetup — play mode', () => {
     })
     vi.mocked(useBases).mockReturnValue({ bases: mockBases, loading: false, error: null })
     const { result } = renderHook(() => useSwuSetup(vi.fn()))
-    act(() => result.current.handlePlayModeChange('bo1'))
-    expect(setItem).toHaveBeenCalledWith('pref_play_mode', 'bo1')
+    act(() => result.current.handleModeChange('tournament'))
+    expect(setItem).toHaveBeenCalledWith('pref_play_mode', 'tournament')
     vi.unstubAllGlobals()
+  })
+
+  it('handleSubmit calls onConfirm with tournament mode when tournament is selected', () => {
+    vi.mocked(useBases).mockReturnValue({ bases: mockBases, loading: false, error: null })
+    const onConfirm = vi.fn()
+    const { result } = renderHook(() => useSwuSetup(onConfirm))
+    act(() => result.current.handleModeChange('tournament'))
+    act(() => result.current.handleSetChange('SOR'))
+    act(() => result.current.handleAspectChange('Aggression'))
+    act(() => result.current.handleKeyChange('SOR-026'))
+    act(() => result.current.handleSubmit())
+    expect(onConfirm).toHaveBeenCalledWith(baseA, 'tournament')
   })
 
 })

--- a/src/test/useTournament.test.ts
+++ b/src/test/useTournament.test.ts
@@ -1,0 +1,592 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useTournament } from '../hooks/useTournament'
+import type { Base } from '../hooks/useBases'
+
+const mockBase: Base = {
+  set: 'SOR',
+  number: '026',
+  name: 'Catacombs of Cadera',
+  subtitle: 'Jedha',
+  hp: 30,
+  frontArt: 'https://cdn.swu-db.com/images/cards/SOR/026.png',
+  frontArtLowRes: null,
+  hyperspaceArtHiRes: null,
+  hyperspaceArt: null,
+  epicAction: '',
+  aspects: ['Aggression'],
+  rarity: 'Common',
+}
+
+const altBase: Base = {
+  set: 'SOR',
+  number: '022',
+  name: 'Energy Conversion Lab',
+  subtitle: 'Eadu',
+  hp: 25,
+  frontArt: 'https://cdn.swu-db.com/images/cards/SOR/022.png',
+  frontArtLowRes: null,
+  hyperspaceArtHiRes: null,
+  hyperspaceArt: null,
+  epicAction: '',
+  aspects: ['Cunning'],
+  rarity: 'Rare',
+}
+
+function setupTournament(
+  result: ReturnType<typeof renderHook<ReturnType<typeof useTournament>, unknown>>['result'],
+  overrides: { totalRounds?: number; playMode?: 'bo1' | 'bo3' } = {},
+) {
+  act(() => result.current.startTournament(
+    mockBase, 'premier', '192916', overrides.playMode ?? 'bo3', overrides.totalRounds ?? 5,
+  ))
+}
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', {
+    getItem: vi.fn().mockReturnValue(null),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('useTournament', () => {
+
+  // --- Initial state ---
+
+  describe('initial state', () => {
+    it('tournament is null when no saved state exists', () => {
+      const { result } = renderHook(() => useTournament())
+      expect(result.current.tournament).toBeNull()
+    })
+
+    it('matchInProgress is false initially', () => {
+      const { result } = renderHook(() => useTournament())
+      expect(result.current.matchInProgress).toBe(false)
+    })
+
+    it('isComplete is false initially', () => {
+      const { result } = renderHook(() => useTournament())
+      expect(result.current.isComplete).toBe(false)
+    })
+
+    it('totals starts at 0-0-0', () => {
+      const { result } = renderHook(() => useTournament())
+      expect(result.current.totals).toEqual({ won: 0, lost: 0, drawn: 0 })
+    })
+  })
+
+  // --- startTournament ---
+
+  describe('startTournament', () => {
+    it('sets tournament with correct base', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      expect(result.current.tournament?.base).toEqual(mockBase)
+    })
+
+    it('sets tournament with correct format', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      expect(result.current.tournament?.format).toBe('premier')
+    })
+
+    it('sets tournament with correct tournamentId', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      expect(result.current.tournament?.tournamentId).toBe('192916')
+    })
+
+    it('sets tournament with correct playMode', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      expect(result.current.tournament?.playMode).toBe('bo3')
+    })
+
+    it('sets tournament with correct totalRounds', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      expect(result.current.tournament?.totalRounds).toBe(5)
+    })
+
+    it('starts with no rounds', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      expect(result.current.tournament?.rounds).toHaveLength(0)
+    })
+
+    it('persists state to localStorage', () => {
+      const setItem = vi.fn()
+      vi.stubGlobal('localStorage', {
+        getItem: vi.fn().mockReturnValue(null),
+        setItem,
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      })
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      expect(setItem).toHaveBeenCalledWith('tournament_state', expect.any(String))
+    })
+
+    it('overwrites an existing tournament', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('won', 2, 0))
+      act(() => result.current.startTournament(altBase, 'limited', '999', 'bo1', 3))
+      expect(result.current.tournament?.rounds).toHaveLength(0)
+      expect(result.current.tournament?.tournamentId).toBe('999')
+      expect(result.current.tournament?.base).toEqual(altBase)
+    })
+  })
+
+  // --- startMatch ---
+
+  describe('startMatch', () => {
+    it('adds a round entry with result null', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      expect(result.current.tournament?.rounds).toHaveLength(1)
+      expect(result.current.tournament?.rounds[0].result).toBeNull()
+    })
+
+    it('sets matchInProgress to true', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      expect(result.current.matchInProgress).toBe(true)
+    })
+
+    it('assigns roundNumber 1 for the first round', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      expect(result.current.tournament?.rounds[0].roundNumber).toBe(1)
+    })
+
+    it('increments roundNumber for subsequent rounds', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('won', 2, 1))
+      act(() => result.current.submitRound())
+      act(() => result.current.startMatch())
+      expect(result.current.tournament?.rounds[1].roundNumber).toBe(2)
+    })
+
+    it('initialises playerScore and opponentScore to 0', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      expect(result.current.tournament?.rounds[0].playerScore).toBe(0)
+      expect(result.current.tournament?.rounds[0].opponentScore).toBe(0)
+    })
+
+    it('initialises submitted to false', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      expect(result.current.tournament?.rounds[0].submitted).toBe(false)
+    })
+
+    it('does nothing if a match is already in progress', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      act(() => result.current.startMatch())
+      expect(result.current.tournament?.rounds).toHaveLength(1)
+    })
+  })
+
+  // --- completeMatch ---
+
+  describe('completeMatch', () => {
+    it('sets result on the current round', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('won', 2, 0))
+      expect(result.current.tournament?.rounds[0].result).toBe('won')
+    })
+
+    it('sets playerScore on the current round', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('won', 2, 1))
+      expect(result.current.tournament?.rounds[0].playerScore).toBe(2)
+    })
+
+    it('sets opponentScore on the current round', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('won', 2, 1))
+      expect(result.current.tournament?.rounds[0].opponentScore).toBe(1)
+    })
+
+    it('sets matchInProgress to false', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('won', 2, 0))
+      expect(result.current.matchInProgress).toBe(false)
+    })
+
+    it('does not mark the round as submitted', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('won', 2, 0))
+      expect(result.current.tournament?.rounds[0].submitted).toBe(false)
+    })
+
+    it('does nothing when no match is in progress', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.completeMatch('won', 2, 0))
+      expect(result.current.tournament?.rounds).toHaveLength(0)
+    })
+  })
+
+  // --- submitRound ---
+
+  describe('submitRound', () => {
+    it('marks the current round as submitted', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('won', 2, 0))
+      act(() => result.current.submitRound())
+      expect(result.current.tournament?.rounds[0].submitted).toBe(true)
+    })
+
+    it('only marks the last round, not previous ones', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('won', 2, 0))
+      act(() => result.current.submitRound())
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('lost', 0, 2))
+      act(() => result.current.submitRound())
+      expect(result.current.tournament?.rounds[0].submitted).toBe(true)
+      expect(result.current.tournament?.rounds[1].submitted).toBe(true)
+    })
+
+    it('does nothing when no completed round exists', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.submitRound())
+      expect(result.current.tournament?.rounds).toHaveLength(0)
+    })
+
+    it('does nothing when the current round is still in progress', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      act(() => result.current.submitRound())
+      expect(result.current.tournament?.rounds[0].submitted).toBe(false)
+    })
+  })
+
+  // --- dropTournament ---
+
+  describe('dropTournament', () => {
+    it('sets tournament to null', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.dropTournament())
+      expect(result.current.tournament).toBeNull()
+    })
+
+    it('removes state from localStorage', () => {
+      const removeItem = vi.fn()
+      vi.stubGlobal('localStorage', {
+        getItem: vi.fn().mockReturnValue(null),
+        setItem: vi.fn(),
+        removeItem,
+        clear: vi.fn(),
+      })
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.dropTournament())
+      expect(removeItem).toHaveBeenCalledWith('tournament_state')
+    })
+
+    it('resets matchInProgress to false', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      act(() => result.current.dropTournament())
+      expect(result.current.matchInProgress).toBe(false)
+    })
+
+    it('resets totals to 0-0-0', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('won', 2, 0))
+      act(() => result.current.dropTournament())
+      expect(result.current.totals).toEqual({ won: 0, lost: 0, drawn: 0 })
+    })
+  })
+
+  // --- setTournamentId ---
+
+  describe('setTournamentId', () => {
+    it('updates the tournamentId', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.setTournamentId('99999'))
+      expect(result.current.tournament?.tournamentId).toBe('99999')
+    })
+
+    it('persists the updated tournamentId to localStorage', () => {
+      const setItem = vi.fn()
+      vi.stubGlobal('localStorage', {
+        getItem: vi.fn().mockReturnValue(null),
+        setItem,
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      })
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      setItem.mockClear()
+      act(() => result.current.setTournamentId('99999'))
+      expect(setItem).toHaveBeenCalledWith('tournament_state', expect.any(String))
+    })
+
+    it('does nothing when no tournament is active', () => {
+      const { result } = renderHook(() => useTournament())
+      act(() => result.current.setTournamentId('99999'))
+      expect(result.current.tournament).toBeNull()
+    })
+  })
+
+  // --- isComplete ---
+
+  describe('isComplete', () => {
+    it('is false when no rounds have been played', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result, { totalRounds: 2 })
+      expect(result.current.isComplete).toBe(false)
+    })
+
+    it('is false when fewer rounds played than totalRounds', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result, { totalRounds: 2 })
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('won', 2, 0))
+      expect(result.current.isComplete).toBe(false)
+    })
+
+    it('is false when the final round is still in progress', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result, { totalRounds: 1 })
+      act(() => result.current.startMatch())
+      expect(result.current.isComplete).toBe(false)
+    })
+
+    it('is true when all rounds have results', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result, { totalRounds: 2 })
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('won', 2, 0))
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('lost', 0, 2))
+      expect(result.current.isComplete).toBe(true)
+    })
+
+    it('is true even when the final round has not been submitted', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result, { totalRounds: 1 })
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('won', 2, 0))
+      expect(result.current.isComplete).toBe(true)
+    })
+  })
+
+  // --- totals ---
+
+  describe('totals', () => {
+    it('returns 0-0-0 with no completed rounds', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      expect(result.current.totals).toEqual({ won: 0, lost: 0, drawn: 0 })
+    })
+
+    it('counts wins correctly', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('won', 2, 0))
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('won', 2, 1))
+      expect(result.current.totals.won).toBe(2)
+    })
+
+    it('counts losses correctly', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('lost', 0, 2))
+      expect(result.current.totals.lost).toBe(1)
+    })
+
+    it('counts draws correctly', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('drawn', 1, 1))
+      expect(result.current.totals.drawn).toBe(1)
+    })
+
+    it('excludes in-progress rounds from totals', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      expect(result.current.totals).toEqual({ won: 0, lost: 0, drawn: 0 })
+    })
+
+    it('counts mixed results correctly', () => {
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('won', 2, 0))
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('lost', 0, 2))
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('drawn', 1, 1))
+      expect(result.current.totals).toEqual({ won: 1, lost: 1, drawn: 1 })
+    })
+  })
+
+  // --- localStorage persistence ---
+
+  describe('localStorage persistence', () => {
+    it('loads saved tournament from localStorage on init', () => {
+      const saved = {
+        base: mockBase,
+        format: 'premier',
+        tournamentId: '192916',
+        playMode: 'bo3',
+        totalRounds: 5,
+        rounds: [{ roundNumber: 1, playerScore: 2, opponentScore: 0, result: 'won', submitted: true }],
+      }
+      vi.stubGlobal('localStorage', {
+        getItem: vi.fn((key: string) => key === 'tournament_state' ? JSON.stringify(saved) : null),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      })
+      const { result } = renderHook(() => useTournament())
+      expect(result.current.tournament?.tournamentId).toBe('192916')
+      expect(result.current.tournament?.rounds).toHaveLength(1)
+    })
+
+    it('restores totals from saved state', () => {
+      const saved = {
+        base: mockBase,
+        format: 'premier',
+        tournamentId: '192916',
+        playMode: 'bo3',
+        totalRounds: 5,
+        rounds: [{ roundNumber: 1, playerScore: 2, opponentScore: 0, result: 'won', submitted: true }],
+      }
+      vi.stubGlobal('localStorage', {
+        getItem: vi.fn((key: string) => key === 'tournament_state' ? JSON.stringify(saved) : null),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      })
+      const { result } = renderHook(() => useTournament())
+      expect(result.current.totals.won).toBe(1)
+    })
+
+    it('restores matchInProgress from saved state when last round has no result', () => {
+      const saved = {
+        base: mockBase,
+        format: 'premier',
+        tournamentId: '192916',
+        playMode: 'bo3',
+        totalRounds: 5,
+        rounds: [{ roundNumber: 1, playerScore: 0, opponentScore: 0, result: null, submitted: false }],
+      }
+      vi.stubGlobal('localStorage', {
+        getItem: vi.fn((key: string) => key === 'tournament_state' ? JSON.stringify(saved) : null),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      })
+      const { result } = renderHook(() => useTournament())
+      expect(result.current.matchInProgress).toBe(true)
+    })
+
+    it('returns null tournament when localStorage contains invalid JSON', () => {
+      vi.stubGlobal('localStorage', {
+        getItem: vi.fn((key: string) => key === 'tournament_state' ? 'not-json' : null),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      })
+      const { result } = renderHook(() => useTournament())
+      expect(result.current.tournament).toBeNull()
+    })
+
+    it('persists state on startMatch', () => {
+      const setItem = vi.fn()
+      vi.stubGlobal('localStorage', {
+        getItem: vi.fn().mockReturnValue(null),
+        setItem,
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      })
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      setItem.mockClear()
+      act(() => result.current.startMatch())
+      expect(setItem).toHaveBeenCalledWith('tournament_state', expect.any(String))
+    })
+
+    it('persists state on completeMatch', () => {
+      const setItem = vi.fn()
+      vi.stubGlobal('localStorage', {
+        getItem: vi.fn().mockReturnValue(null),
+        setItem,
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      })
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      setItem.mockClear()
+      act(() => result.current.completeMatch('won', 2, 0))
+      expect(setItem).toHaveBeenCalledWith('tournament_state', expect.any(String))
+    })
+
+    it('persists state on submitRound', () => {
+      const setItem = vi.fn()
+      vi.stubGlobal('localStorage', {
+        getItem: vi.fn().mockReturnValue(null),
+        setItem,
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      })
+      const { result } = renderHook(() => useTournament())
+      setupTournament(result)
+      act(() => result.current.startMatch())
+      act(() => result.current.completeMatch('won', 2, 0))
+      setItem.mockClear()
+      act(() => result.current.submitRound())
+      expect(setItem).toHaveBeenCalledWith('tournament_state', expect.any(String))
+    })
+  })
+
+})

--- a/src/utils/playMode.ts
+++ b/src/utils/playMode.ts
@@ -7,3 +7,12 @@ export const PLAY_MODE_LABELS: Record<PlayMode, string> = {
 }
 
 export const PLAY_MODES: PlayMode[] = ['casual', 'bo1', 'bo3']
+
+export type SetupMode = 'casual' | 'tournament'
+
+export const SETUP_MODE_LABELS: Record<SetupMode, string> = {
+  casual: 'Casual',
+  tournament: 'Tournament',
+}
+
+export const SETUP_MODES: SetupMode[] = ['casual', 'tournament']


### PR DESCRIPTION
adds the data model for the tournament mode, replacing bo1 and bo3

Closes #204 