### PR TITLE
feat/greedy-ai

### DIFF
--- a/sealed/docs/ai-benchmark.md
+++ b/sealed/docs/ai-benchmark.md
@@ -31,16 +31,20 @@ Everything is optional:
 - `--games N` how many games to play (default 100).
 - `--seed N` the run's seed (default 1). The same seed reproduces the run exactly.
 - `aiA aiB` the two AIs by name (default `random random`). `aiA` plays the "player" seat, `aiB` the
-  "opponent" seat. Currently `random` is the only registered AI; `greedy` and others join the list as
-  they are built.
+  "opponent" seat. The registered AIs are `random` (rung 0, uniform) and `greedy` (rung 1, one-ply);
+  more join the list as they are built.
 
 Examples:
 
 ```bash
 npm run bench --prefix sealed                                  # 100 games, random vs random
 npm run bench --prefix sealed -- --games 1000 --seed 42        # a big, reproducible run
-npm run bench --prefix sealed -- --games 500 greedy random     # once greedy exists
+npm run bench --prefix sealed -- --games 1000 greedy random    # measure the greedy AI
 ```
+
+Recorded baselines (mirror deck, so purely AI skill): `random` vs `random` sits at 50% (the harness
+self-check), and `greedy` vs `random` is ~100% over 1000 games, the one-ply scorer demolishing
+uniform-random play.
 
 Note the `--` after the script name: it tells npm to pass the flags through to the bench rather than
 eat them itself.

--- a/sealed/docs/architecture.md
+++ b/sealed/docs/architecture.md
@@ -50,7 +50,10 @@ Design properties that matter for later epics:
   the state**: the same position always draws the same reply, while any different line of play
   carries a different seed and is free to diverge. Opponents are swappable via
   `UseGameOptions.ai` (tests inject a passive one; smarter rungs slot in the same way), and are
-  addressed by name through the registry in `ai/registry.ts`.
+  addressed by name through the registry in `ai/registry.ts`. The **deployed** opponent is a single
+  config constant, `OPPONENT_AI` in `src/config.ts` (currently `greedy`): shipping a new model is a
+  one-line change plus a redeploy, deliberately a reviewed deployment setting rather than a user
+  choice.
 - **Measurability.** Because the AI is pure and seeded, a headless harness can play thousands of
   games between two named AIs and report reproducible win rates. That harness (`src/bench/`, run with
   `npm run bench`) is the yardstick for the AI series; see [ai-benchmark.md](ai-benchmark.md).

--- a/sealed/docs/operations.md
+++ b/sealed/docs/operations.md
@@ -242,8 +242,10 @@ field names, update `SwuCard` (`data/cards.ts`) and `normaliseCard`
   `(state) => Action | null` choosing from `legalMoves(state)`, drawing any
   randomness from `state.rngSeed` so games stay replayable. Register it by name in
   `ai/registry.ts`, then measure it with `npm run bench` (see
-  [ai-benchmark.md](ai-benchmark.md)). Swap it into the app via `UseGameOptions.ai`.
-  Move to a Web Worker (T5.4) before MCTS.
+  [ai-benchmark.md](ai-benchmark.md)). **Deploy** a model by setting `OPPONENT_AI` in
+  `src/config.ts` to its registered name and redeploying (a reviewed one-line change, not a
+  user choice); tests still inject their own via `UseGameOptions.ai`. Move to a Web Worker
+  (T5.4) before MCTS. The current deployed model is `greedy` (one-ply, beats `random` ~100%).
 - **Abilities/keywords**: extend `EngineCard` with parsed ability data in
   `cardDb.ts`, generate/resolve in `legalMoves.ts`/`resolve.ts`. Keep both pure.
 - **Schema changes**: `GameState` changes ripple into `engineFixtures.ts` and the

--- a/sealed/src/ai/evaluate.ts
+++ b/sealed/src/ai/evaluate.ts
@@ -1,0 +1,68 @@
+import type { GameState, PlayerId } from '../engine/types'
+import { opponentOf } from '../engine/types'
+import { effectivePower, effectiveHp } from '../engine/stats'
+
+/**
+ * Board evaluation for the greedy AI (#391): a single number, higher is better for `me`.
+ *
+ * It is deliberately zero-sum (everything is "my stuff minus their stuff"), so
+ * `evaluate(s, player) === -evaluate(s, opponent)`. That is both correct for a two-player game
+ * (building your board and dismantling theirs are the same act) and a clean invariant to rely on.
+ *
+ * Weights are integers so scores compare exactly (no float-epsilon fuzz in the greedy tie-break),
+ * and are ordered per the ticket: winning dominates, then enemy base damage (the win condition),
+ * then board presence, then card advantage, then tempo. They are starting values, tuned against the
+ * benchmark. This function is the seam later tickets grow (#392 trades, #395 role, #396 tokens).
+ */
+
+/** A decisive result outweighs any reachable material score. */
+const WIN = 1_000_000
+// A point of base damage matters, but must not outweigh removing a real threat: a single big unit
+// (say 5/6 = 22 board) should be worth more than one point on the base, or the AI races face and
+// never trades. So base damage is weighted well below a unit's board presence.
+const W_BASE_DAMAGE = 3 // per point of damage on a base (the win condition)
+const W_POWER = 2 // per point of a unit's effective power
+const W_HP = 2 // per point of a unit's remaining HP
+const W_CARD = 2 // per card in hand
+// Economy is the TOTAL resource pool, not the ready count: resources exhaust to pay costs and ready
+// again next round, so counting ready ones would wrongly read "played a unit" as a loss and deter
+// development. Total resources only grow (by resourcing), so this rewards ramping and ignores spend.
+const W_RESOURCE = 3 // per resource in the pool
+const W_READY_UNIT = 1 // per ready (unexhausted) unit, a light tempo term
+
+/** Summed power + remaining HP of a player's units in play (deployed leaders included, they live here). */
+function boardPresence(state: GameState, id: PlayerId): number {
+  let total = 0
+  for (const unit of state.players[id].units) {
+    total += W_POWER * effectivePower(state, unit)
+    total += W_HP * Math.max(0, effectiveHp(state, unit) - unit.damage)
+  }
+  return total
+}
+
+function totalResources(state: GameState, id: PlayerId): number {
+  return state.players[id].resources.length
+}
+
+function readyUnits(state: GameState, id: PlayerId): number {
+  return state.players[id].units.filter(u => !u.exhausted).length
+}
+
+/** How good `state` is for `me`. */
+export function evaluate(state: GameState, me: PlayerId): number {
+  if (state.winner === me) return WIN
+  if (state.winner === 'draw') return 0
+  if (state.winner !== null) return -WIN
+
+  const foe = opponentOf(me)
+
+  // Damage on the enemy base is progress toward winning; damage on ours is progress toward losing.
+  const baseTerm = W_BASE_DAMAGE * (state.players[foe].base.damage - state.players[me].base.damage)
+
+  const board = boardPresence(state, me) - boardPresence(state, foe)
+  const cards = W_CARD * (state.players[me].hand.length - state.players[foe].hand.length)
+  const resources = W_RESOURCE * (totalResources(state, me) - totalResources(state, foe))
+  const tempo = W_READY_UNIT * (readyUnits(state, me) - readyUnits(state, foe))
+
+  return baseTerm + board + cards + resources + tempo
+}

--- a/sealed/src/ai/greedyAi.ts
+++ b/sealed/src/ai/greedyAi.ts
@@ -1,0 +1,39 @@
+import type { Action } from '../engine/actions'
+import type { GameState } from '../engine/types'
+import { legalMoves } from '../engine/legalMoves'
+import { resolve } from '../engine/resolve'
+import { seededUnit } from '../engine/rng'
+import { evaluate } from './evaluate'
+
+/**
+ * Rung-1 opponent: one-ply greedy. For each legal move, apply it and score the resulting board from
+ * the perspective of the player to move; take the highest. Because `resolve` is pure and
+ * `legalMoves` enumerates everything (including how choices are answered), this one loop covers
+ * playing, attacking, resourcing, taking the initiative and answering triggers, with no per-card
+ * rules. See `evaluate` for the scoring.
+ *
+ * Determinism is a hard requirement (#366): ties are broken from `state.rngSeed`, never `Math.random`,
+ * so replays and saved records reproduce exactly. The scoring `resolve` calls advance the seed only
+ * on their own discarded copies; the real seed advances once, when the chosen move is actually
+ * applied, so it stays a pure function of state.
+ */
+export function greedyAi(state: GameState): Action | null {
+  const moves = legalMoves(state)
+  if (moves.length === 0) return null
+
+  const me = state.activePlayer
+  let best = -Infinity
+  const bestMoves: Action[] = []
+  for (const move of moves) {
+    const score = evaluate(resolve(state, move), me)
+    if (score > best) {
+      best = score
+      bestMoves.length = 0
+      bestMoves.push(move)
+    } else if (score === best) {
+      bestMoves.push(move)
+    }
+  }
+
+  return bestMoves[Math.floor(seededUnit(state.rngSeed) * bestMoves.length)]
+}

--- a/sealed/src/ai/registry.ts
+++ b/sealed/src/ai/registry.ts
@@ -1,5 +1,6 @@
 import type { Ai } from './types'
 import { randomAi } from './randomAi'
+import { greedyAi } from './greedyAi'
 
 /**
  * The named-AI registry: the single place that knows which opponents exist. The bench addresses
@@ -8,6 +9,7 @@ import { randomAi } from './randomAi'
  */
 export const AIS: Record<string, Ai> = {
   random: randomAi,
+  greedy: greedyAi,
 }
 
 /** The names the CLI and any picker can offer. */

--- a/sealed/src/buildTag.ts
+++ b/sealed/src/buildTag.ts
@@ -3,4 +3,4 @@
  * browser running?" is answerable at a glance. Shown bottom-right in dev, and at
  * the foot of the Help page in prod.
  */
-export const BUILD_TAG = 'b356'
+export const BUILD_TAG = 'b358'

--- a/sealed/src/config.ts
+++ b/sealed/src/config.ts
@@ -1,0 +1,16 @@
+import type { Ai } from './ai/types'
+import { resolveAi } from './ai/registry'
+
+/**
+ * Deployment configuration for the sealed app.
+ *
+ * `OPPONENT_AI` is the AI model the build ships against. It is a **deployment** setting, not a user
+ * choice: to release a new model, change this to another registered name (see `ai/registry.ts`) and
+ * redeploy. Keeping it a single reviewed constant means every model change is a visible one-line diff
+ * in a pull request, which is the gate for shipping a model only once we are happy with it. A
+ * user-facing difficulty picker could sit on top of this later; for now it is fixed per deploy.
+ */
+export const OPPONENT_AI = 'greedy'
+
+/** The resolved opponent AI. Throws at load if `OPPONENT_AI` is not a registered name (fail fast). */
+export const opponentAi: Ai = resolveAi(OPPONENT_AI)

--- a/sealed/src/hooks/useGame.ts
+++ b/sealed/src/hooks/useGame.ts
@@ -11,7 +11,7 @@ import type { Action } from '../engine/actions'
 import type { GameState, PlayerId } from '../engine/types'
 import { legalMoves } from '../engine/legalMoves'
 import { resolve } from '../engine/resolve'
-import { randomAi } from '../ai/randomAi'
+import { opponentAi } from '../config'
 import { setupAi } from '../ai/setupAi'
 import { describeActionParts, partsText } from '../utils/describeAction'
 import type { DescribePart } from '../utils/describeAction'
@@ -122,7 +122,7 @@ export function useGame(playerDeck: SavedDeck, opponentDeck: SavedDeck, options:
 
   const rng = options.rng ?? Math.random
   const shuffle = options.shuffle ?? fisherYates
-  const ai = options.ai ?? randomAi
+  const ai = options.ai ?? opponentAi
 
   const initialStateRef = useRef<GameState | null>(null)
   const movesRef = useRef<MoveRecord[]>([])

--- a/sealed/src/test/aiEvaluate.test.ts
+++ b/sealed/src/test/aiEvaluate.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { evaluate } from '../ai/evaluate'
+import { state, player, unit } from './helpers/engineFixtures'
+
+/**
+ * The board evaluation the greedy AI maximises (#391). Higher is better for `me`. It is the seam the
+ * later tickets grow (#392 trades, #395 role, #396 tokens); these tests pin the invariants it must
+ * always hold: winning beats losing, your own board and card advantage help, damage to the enemy
+ * base helps and damage to yours hurts, and the whole thing is zero-sum from the two seats' views.
+ */
+describe('evaluate', () => {
+  it('scores a win far above a loss', () => {
+    const won = state({ winner: 'player' })
+    expect(evaluate(won, 'player')).toBeGreaterThan(0)
+    expect(evaluate(won, 'opponent')).toBeLessThan(0)
+    // A win dwarfs any material term: a lone unit cannot outweigh it.
+    const material = state({ players: { player: player({ units: [unit('u1', 'TST_U1')] }), opponent: player() } })
+    expect(evaluate(won, 'player')).toBeGreaterThan(evaluate(material, 'player'))
+  })
+
+  it('is zero-sum: the two seats see equal and opposite scores', () => {
+    const s = state({
+      players: {
+        player: player({ units: [unit('u1', 'TST_U1')], hand: ['TST_U1'], base: { cardId: 'TST_B', damage: 3 } }),
+        opponent: player({ units: [unit('e1', 'TST_U2')], base: { cardId: 'TST_B', damage: 1 } }),
+      },
+    })
+    expect(evaluate(s, 'player')).toBe(-evaluate(s, 'opponent'))
+  })
+
+  it('values having a board over not having one', () => {
+    const withUnit = state({ players: { player: player({ units: [unit('u1', 'TST_U1')] }), opponent: player() } })
+    expect(evaluate(withUnit, 'player')).toBeGreaterThan(0)
+  })
+
+  it('rewards damage on the enemy base and punishes damage on your own', () => {
+    const level = state()
+    const hitEnemy = state({ players: { player: player(), opponent: player({ base: { cardId: 'TST_B', damage: 5 } }) } })
+    const hitSelf = state({ players: { player: player({ base: { cardId: 'TST_B', damage: 5 } }), opponent: player() } })
+    expect(evaluate(hitEnemy, 'player')).toBeGreaterThan(evaluate(level, 'player'))
+    expect(evaluate(hitSelf, 'player')).toBeLessThan(evaluate(level, 'player'))
+  })
+
+  it('counts card advantage', () => {
+    const ahead = state({ players: { player: player({ hand: ['TST_U1', 'TST_U1'] }), opponent: player({ hand: [] }) } })
+    expect(evaluate(ahead, 'player')).toBeGreaterThan(0)
+  })
+})

--- a/sealed/src/test/aiRegistry.test.ts
+++ b/sealed/src/test/aiRegistry.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { AIS, aiNames, resolveAi } from '../ai/registry'
 import { randomAi } from '../ai/randomAi'
+import { greedyAi } from '../ai/greedyAi'
 
 /**
  * The named-AI registry is the single seam every opponent hangs off: the bench addresses AIs by
@@ -15,6 +16,7 @@ describe('AI registry', () => {
 
   it('resolves a known name to its function', () => {
     expect(resolveAi('random')).toBe(randomAi)
+    expect(resolveAi('greedy')).toBe(greedyAi)
   })
 
   it('rejects an unknown name with a message that lists the valid ones', () => {

--- a/sealed/src/test/benchGreedy.test.ts
+++ b/sealed/src/test/benchGreedy.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { runBench } from '../bench/runBench'
+
+/**
+ * The point of the greedy AI (#391): it must beat `random` decisively. This is a small, seeded
+ * regression guard, the decisive numbers come from a large CLI run (`npm run bench`). The threshold
+ * is deliberately loose (observed is ~100%); it exists to catch an evaluation change that quietly
+ * tanks greedy, not to pin an exact rate.
+ */
+describe('greedy vs random benchmark', () => {
+  it('beats random by a wide margin over a seeded run', () => {
+    const report = runBench({ games: 40, seed: 7, aiA: 'greedy', aiB: 'random' })
+    expect(report.dropped).toBe(0)
+    expect(report.winRateA).toBeGreaterThan(0.75)
+  })
+})

--- a/sealed/src/test/config.test.ts
+++ b/sealed/src/test/config.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { OPPONENT_AI, opponentAi } from '../config'
+import { resolveAi, aiNames } from '../ai/registry'
+
+/**
+ * The app's opponent is a DEPLOYMENT setting, not a user choice: `OPPONENT_AI` names the model the
+ * build ships against, and shipping a new one is a one-line change here plus a redeploy. These tests
+ * pin that the configured name is real (so a typo fails the build, not the user at runtime) and
+ * record the current default.
+ */
+describe('deployment config', () => {
+  it('names a registered AI', () => {
+    expect(aiNames()).toContain(OPPONENT_AI)
+  })
+
+  it('resolves to that AI', () => {
+    expect(opponentAi).toBe(resolveAi(OPPONENT_AI))
+  })
+
+  it('currently deploys the greedy model', () => {
+    expect(OPPONENT_AI).toBe('greedy')
+  })
+})

--- a/sealed/src/test/greedyAi.test.ts
+++ b/sealed/src/test/greedyAi.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { greedyAi } from '../ai/greedyAi'
+import '../engine/cardDefinitions' // side-effect: registers every implemented card
+import { state, player, unit, card, CARDS, ready } from './helpers/engineFixtures'
+import type { Action } from '../engine/actions'
+
+/**
+ * The greedy driver (#391): for each legal move, apply it, score the resulting board, take the best,
+ * ties broken from the seed. It needs no per-card rules because `resolve` and `legalMoves` already
+ * know everything. One ply, so it evaluates AFTER our move but before the reply: it avoids an
+ * immediately-bad trade (combat resolves in-move) but cannot see the opponent's next turn (#392).
+ */
+describe('greedyAi', () => {
+  it('is deterministic: the same state yields the same move', () => {
+    const s = state({ players: { player: player({ hand: ['TST_U1'], resources: ready(2) }), opponent: player() } })
+    expect(greedyAi(s)).toEqual(greedyAi(s))
+  })
+
+  it('takes a lethal attack rather than passing', () => {
+    const s = state({
+      players: {
+        player: player({ units: [unit('u1', 'TST_U3')] }), // power 5, ready
+        opponent: player({ base: { cardId: 'TST_B', damage: 26 } }), // 26 + 5 >= 30
+      },
+    })
+    const move = greedyAi(s) as Action
+    expect(move.type).toBe('attack')
+    expect(move.type === 'attack' && move.target.kind).toBe('base')
+  })
+
+  it('does not throw itself into a losing trade', () => {
+    const s = state({
+      cards: {
+        ...CARDS,
+        WEAK: card({ id: 'WEAK', type: 'unit', arena: 'ground', power: 1, hp: 1 }),
+        TANK: card({ id: 'TANK', type: 'unit', arena: 'ground', power: 2, hp: 5 }),
+      },
+      players: {
+        player: player({ units: [unit('u1', 'WEAK')] }),
+        opponent: player({ units: [unit('e1', 'TANK')] }),
+      },
+    })
+    const move = greedyAi(s) as Action
+    // Attacking the 5-HP tank with a 1/1 loses the unit for nothing; greedy must not pick that.
+    const suicidal = move.type === 'attack' && move.target.kind === 'unit' && move.target.instanceId === 'e1'
+    expect(suicidal).toBe(false)
+  })
+
+  it('develops a unit rather than passing when it can', () => {
+    const s = state({ players: { player: player({ hand: ['TST_U1'], resources: ready(2) }), opponent: player() } })
+    const move = greedyAi(s) as Action
+    expect(move.type).toBe('playUnit')
+  })
+})


### PR DESCRIPTION
sets the greedyAI as the default opponent and sets the deployment structure to push different models in future

Closes #391 