### PR TITLE
feat/self-lookahead

### DIFF
--- a/sealed/docs/ai-benchmark.md
+++ b/sealed/docs/ai-benchmark.md
@@ -65,6 +65,11 @@ Everything is optional:
   - `greedy-baseline` a frozen early greedy, kept only as a fixed reference for tuning.
   - `greedy-flat` the live model minus quiescent scoring. Unlike the baseline it tracks every other
     evaluation change, which is what makes it a control for that one feature rather than a snapshot.
+  - `beam` rung 2, own-turn lookahead at width 4, depth 3. Same weights and same chain handling as
+    `greedy`, so `beam` against `greedy` isolates the search.
+  - `beam:WIDTHxDEPTH` or `beam:WIDTHxDEPTH:NODES` any other cell, so a sweep addresses the space
+    without a registry entry per cell. The node form exists for one control: the budget is a safety
+    rail, and a rail that fires has quietly become the real width and depth.
 
   More join the list as they are built.
 
@@ -83,7 +88,13 @@ plain pass: 3 games a deck is ~20 minutes and is plenty for rates of this size.
 
 Recorded baselines (mirror deck, so purely AI skill): `random` vs `random` sits at 50% (the harness
 self-check), and `greedy` vs `random` is ~100% over 1000 games, the one-ply scorer demolishing
-uniform-random play.
+uniform-random play. `greedy` against **itself** reads 50.4% ± 3.4% over 840 games, which is the
+control every comparison against `greedy` rests on. `beam` against `greedy` is 60.0% over three seeds.
+
+**A search config costs what it costs.** Measured solo on one corpus of real decisions, `greedy` is
+2.49 ms/decision, `beam:2x3` 62 ms, `beam:4x3` 85 ms and `beam:8x3` 122 ms. Do not take these from a
+bench wall clock: a game's clock includes the opponent's cheap decisions and engine overhead, which
+diluted the same ratio to 12x when it is really about 34x.
 
 Note the `--` after the script name: it tells npm to pass the flags through to the bench rather than
 eat them itself.

--- a/sealed/docs/ai-model.md
+++ b/sealed/docs/ai-model.md
@@ -64,6 +64,66 @@ Two properties worth keeping:
 `greedy-flat` in the registry is the same AI without this, kept so the comparison can be re-run as
 the evaluation changes underneath it.
 
+## Own-turn lookahead: the beam
+
+One ply scores each move in isolation, so it can never play a line whose first step is a loss.
+Sacrificing a chump into a Sentinel to clear the path is the canonical case: the sacrifice is simply
+bad, and the payoff arrives two actions later.
+
+The beam expands a sequence of **our own** actions and values a move by the best board its follow-ups
+reach. It ships at **width 4, depth 3**, and measures **60.0%** against one-ply greedy over three
+seeds and 2580 games (57.5%, 59.0%, 63.5%), where greedy against itself reads 50.4%.
+
+### The null-move assumption
+
+Players alternate single actions, so continuing our own sequence means pretending the opponent does
+nothing in between. **That assumption, not the search, is where the strength comes from and where it
+leaks.** Since the beam maximises over leaves, it systematically prefers the branch most dependent on
+the assumption holding.
+
+It models this format better than it sounds. There is no instant-speed interaction and a played unit
+arrives exhausted, so an opponent cannot answer mid-sequence with a card they have just cast. Their
+whole in-sequence toolkit is: attack with something already ready, play an event, play an Ambush
+unit, deploy their leader (which arrives ready, and is the largest of these), or claim.
+
+The null move is the real `pass` action rather than a rewrite of `activePlayer`, which is safe because
+every real action resets the pass counter before handing the turn over, so alternating our-action and
+their-pass never reaches the two-pass phase end. The search never passes on our own behalf.
+
+### Three properties that are not obvious
+
+- **Each root keeps its own beam.** A single global frontier would defeat the purpose: these lines
+  open with a move that is bad in isolation, so trimming by immediate score prunes exactly the roots
+  worth exploring. Per-root beams cost roughly `roots × width × depth` instead of `width × depth`, and
+  that is the price of the feature working rather than an optimisation left unclaimed.
+- **Decisive scores are discounted by depth.** Without it the beam is indifferent between winning now
+  and winning in three actions, since both score WIN. A deferred win is certain only if the opponent
+  really does nothing. The discount touches decided boards only, so it reorders no material judgement.
+- **The beam expands actions; quiescence owns the chains.** `resolveChain` settles an owed choice and
+  returns the board, so depth counts genuine actions. Otherwise a `support` chain would consume beam
+  width and depth would mean something different in every position.
+
+### Width and depth
+
+Depth does the work; width barely matters and is mildly harmful past 4.
+
+| | Win rate | ms/decision |
+| --- | --- | --- |
+| depth 2 (any width) | 54.0% | |
+| width 2, depth 3 | 59.2% | 62 |
+| **width 4, depth 3** | **60.0%** | **85** |
+| width 8, depth 3 | 56.1% | 122 |
+
+Width is provably irrelevant at depth 2, where the trim is never used, and every depth-2 cell returns
+bit-identical numbers. Width 8 losing to width 4 is consistent with the optimism story: a wider beam
+keeps more mediocre states, and a max over more leaves is more optimistic.
+
+**Depth 4 is better and is deliberately not shipped.** It measures 59.4% against depth 3's 57.5% on
+the same seed, but only once the node budget is raised: at the default budget it reports 54.4%,
+because the rail truncates it. It costs 2.45x, and its value rests on four consecutive opponent
+non-actions, which is exactly what a modelled reply changes. The decision belongs with the reply
+policy rather than before it.
+
 ## The two halves of `evaluate`
 
 The split is a **hidden-information boundary**, not a tidiness one.
@@ -294,6 +354,14 @@ Three properties keep it from disturbing anything else:
 The reading is a lower bound. `canFinishThisAction` sees only damage already on the board, so an
 event finisher, an Ambush unit or a pump in hand is invisible to it. Closing that gap is search, not
 a weight.
+
+Two of the gaps are **public** rather than hidden, and are worth knowing before the bound is trusted.
+A leader deploys **ready** and deploys on resources controlled rather than spent, so an undeployed
+leader is a ready attacker its owner can produce at will; deploying is itself an action, so it is
+normally a two-action line, but a leader granted Ambush on deploy swings in the same action. And a
+few units ready themselves while some events ready an exhausted one, so `exhausted` is not the last
+word on whether a body can attack again this round. Both are narrow enough not to earn a term, and
+both make the race model under-read a player who is about to deploy.
 
 ### Role: read the race, not the board
 

--- a/sealed/docs/planned-work.md
+++ b/sealed/docs/planned-work.md
@@ -58,6 +58,21 @@ and search rather than to a belief model. This is the gate on #434 to #439 below
 when-played base hit is invisible to it, so both the lethal readout and the shipped exposure term are
 lower bounds. Closing that gap is search, which is #433.
 
+Two of the gaps are **public**: a leader deploys ready, so an undeployed leader is an attacker its
+owner can produce at will, and a few units ready themselves while some events ready an exhausted one.
+Neither earns a term, and both make the race model under-read a player about to deploy.
+
+### Some of what the model knows may be standing in for search
+
+`lethalExposure` is a static proxy for "they can kill me next action"; `role` is a static proxy for
+trajectory. A deeper search computes both directly, so their measured value should **shrink** as depth
+rises, and once #425 models the reply, `lethalExposure` risks double-counting outright.
+
+That decides what transfers between search configurations. Changes that add **information the search
+cannot get** carry over; changes that **proxy for search** do not. `--terms` is the instrument: watch
+the Bearing column for those two terms as depth rises. It is recorded on #447 so it can be judged
+rather than argued.
+
 ## One search, several policies
 
 The search tickets are not separate features. They are **one bounded tree search over `legalMoves`**
@@ -77,20 +92,23 @@ bot.
 
 ## Next up
 
-1. **#410 own-turn beam.** Expanding **separate actions**, with a null move for the opponent, beam
-   width K over depth, role fixed once at the root. The null-move assumption is where the strength
-   comes from and where it leaks. **Its original justification is gone**: it was sized on attack ties
-   at 10.2%, now 1.7% once quiescent scoring landed. It now rests on initiative (the table above) and
-   on the multi-step lines themselves, which need a scripted position rather than a rate.
-2. **#433 lethal, as a terminal condition of #410**, not a standalone solver. "Can I win this turn"
+1. **#433 lethal, as a terminal condition of #410**, not a standalone solver. "Can I win this turn"
    assumes the opponent does nothing, which is #410's null-move assumption, so this is that search
    with a different finish line. What it adds is the **hand**: a burn event, a pump, a when-played
    base hit, or clearing a Sentinel then swinging. (Ambush is not a closer: `legalMoves` only ever
    offers it unit targets, so it reaches a base solely via Overwhelm.)
-3. **#425 opponent reply**, public information only. The cheap first step into pessimistic search.
+2. **#425 opponent reply**, public information only. The cheap first step into pessimistic search.
+3. **#446 claim the initiative when it converts to lethal.** Split out of #410, which could not build
+   it: the check is `hasLethal` from #433, and it needs the sequence to continue across a **round
+   boundary** rather than to the end of a turn. Initiative is still the largest single tie at 18.2%,
+   ~7.4 coin flips a game.
 4. **Re-run `--terms`** once the matrix lands, and compare against the pre-registered predictions on
    #430: `resourceSurplus`, `saturation`, `hand.canAct` and `roleShift` should start mattering if they
    were dormant. Anything still flat is dead and can be deleted.
+5. **#447 final search configuration**, after #425 and not before. Depth, width and reply policy get
+   chosen jointly, because they are not independent: depth 4 measured **better** than the shipped
+   depth 3 and was banked rather than shipped, since its value rests on four consecutive opponent
+   non-actions and #425 is what changes that.
 
 **Measure four configurations, not two.** #410 is optimistic (the opponent does nothing) while #425
 is pessimistic (they do the worst visible thing). Those pull in opposite directions and may not

--- a/sealed/src/ai/greedyAi.ts
+++ b/sealed/src/ai/greedyAi.ts
@@ -6,7 +6,7 @@ import { resolve } from '../engine/resolve'
 import { seededUnit } from '../engine/rng'
 import { evaluate, makeEvaluate, DEFAULT_WEIGHTS, type Evaluator, type EvalWeights } from './evaluate'
 import { evaluateBaseline } from './evaluateBaseline'
-import { makeQuiescent } from './search'
+import { makeQuiescent, makeBeamAi, type BeamLimits } from './search'
 import { role } from './race'
 
 /**
@@ -72,3 +72,16 @@ export const greedyFlatAi = makeGreedyAi(evaluate)
 
 /** The frozen pre-#392 greedy, kept only as a fixed comparison point for the generalisation runs. */
 export const greedyBaselineAi = makeGreedyAi(evaluateBaseline)
+
+/**
+ * Own-turn self-lookahead (#410) on the shipped evaluation: the same weights and the same quiescent
+ * chain handling as `greedy`, differing only in expanding our own follow-up actions.
+ *
+ * Built here rather than in `search.ts` so there is still one construction site per bot, and so an
+ * A/B against `greedy` isolates the beam and nothing else.
+ */
+export function makeBeamGreedy(weights: EvalWeights, limits?: BeamLimits): Ai {
+  return makeBeamAi(makeEvaluate(weights), limits)
+}
+
+export const beamAi = makeBeamGreedy(DEFAULT_WEIGHTS)

--- a/sealed/src/ai/race.ts
+++ b/sealed/src/ai/race.ts
@@ -134,6 +134,19 @@ function remainingBase(state: GameState, seat: PlayerId): number {
  *
  * Still blind to the hand, so it remains a lower bound: an event finisher, an Ambush unit or a pump
  * can all win in one action and none of them are visible here.
+ *
+ * It is also blind to two things that are fully PUBLIC, which is worth knowing before trusting it:
+ *
+ * - **An undeployed leader.** Leaders deploy READY (CR 3.4.4) and deploy on resources CONTROLLED
+ *   rather than spent, so a leader is a ready attacker its owner can produce at will. Deploying is
+ *   itself the action, so it is usually a two-action line and correctly excluded here, but a leader
+ *   granted Ambush on deploy attacks as part of the same action and is a genuine one-action miss.
+ * - **Ready effects.** A handful of units ready themselves and some events ready an exhausted unit,
+ *   so `exhausted` is not the last word on whether a body can still attack this round.
+ *
+ * Neither is worth a term of its own: both are narrow, and the estimate exists to rank two clocks
+ * cheaply rather than to be right in every position. They are recorded so the bound is read as a
+ * bound.
  */
 export function canFinishThisAction(state: GameState, seat: PlayerId): boolean {
   const remaining = remainingBase(state, seat)

--- a/sealed/src/ai/registry.ts
+++ b/sealed/src/ai/registry.ts
@@ -1,6 +1,8 @@
 import type { Ai } from './types'
 import { randomAi } from './randomAi'
-import { greedyAi, greedyBaselineAi, greedyFlatAi } from './greedyAi'
+import { greedyAi, greedyBaselineAi, greedyFlatAi, beamAi, makeBeamGreedy } from './greedyAi'
+import { DEFAULT_BEAM_LIMITS } from './search'
+import { DEFAULT_WEIGHTS } from './evaluate'
 
 /**
  * The named-AI registry: the single place that knows which opponents exist. The bench addresses
@@ -16,6 +18,10 @@ export const AIS: Record<string, Ai> = {
   // The live greedy minus quiescent scoring, so that one change can be measured on its own. Unlike
   // the baseline this tracks every other evaluation change, which is what makes it a control.
   'greedy-flat': greedyFlatAi,
+  // The live greedy PLUS own-turn lookahead: same weights, same chain handling, so `beam` against
+  // `greedy` isolates the search. Optimistic by construction (it assumes the opponent does nothing),
+  // which is why it is measured alongside a pessimistic policy rather than on its own.
+  beam: beamAi,
 }
 
 /** The names the CLI and any picker can offer. */
@@ -23,11 +29,33 @@ export function aiNames(): string[] {
   return Object.keys(AIS)
 }
 
+/**
+ * `beam:WIDTHxDEPTH` or `beam:WIDTHxDEPTH:NODES`, so a sweep can address any cell without the
+ * registry growing a line per cell. `beam` on its own is the shipped configuration.
+ *
+ * The optional node budget exists for one specific control: the budget is a safety rail, and a rail
+ * that fires routinely has quietly become the real width and depth. Re-running a cell with it raised
+ * tenfold shows whether the swept axes mean anything.
+ */
+const BEAM_SPEC = /^beam:(\d+)x(\d+)(?::(\d+))?$/
+
 /** Look up an AI by name, failing loudly (and helpfully) on a typo rather than silently. */
 export function resolveAi(name: string): Ai {
   const ai = AIS[name]
-  if (!ai) {
-    throw new Error(`Unknown AI "${name}". Available: ${aiNames().join(', ')}`)
+  if (ai) return ai
+
+  const spec = BEAM_SPEC.exec(name)
+  if (spec) {
+    const width = Number(spec[1])
+    const depth = Number(spec[2])
+    const nodes = spec[3] === undefined ? DEFAULT_BEAM_LIMITS.nodes : Number(spec[3])
+    // A zero width or depth would search nothing while still looking like a configured beam, which is
+    // the kind of thing that silently costs a night of measurement.
+    if (width < 1 || depth < 1 || nodes < 1) {
+      throw new Error(`Beam "${name}" needs width, depth and nodes of at least 1`)
+    }
+    return makeBeamGreedy(DEFAULT_WEIGHTS, { width, depth, nodes })
   }
-  return ai
+
+  throw new Error(`Unknown AI "${name}". Available: ${aiNames().join(', ')}, or beam:WIDTHxDEPTH[:NODES]`)
 }

--- a/sealed/src/ai/search.ts
+++ b/sealed/src/ai/search.ts
@@ -1,9 +1,13 @@
 import type { GameState, PlayerId } from '../engine/types'
+import type { Action } from '../engine/actions'
 import type { Evaluator } from './evaluate'
+import type { Ai } from './types'
 import type { Role } from './race'
 import { hasPendingChoices } from '../engine/types'
 import { legalMoves } from '../engine/legalMoves'
 import { resolve } from '../engine/resolve'
+import { seededUnit } from '../engine/rng'
+import { role } from './race'
 
 /**
  * Quiescent scoring: never evaluate a half-resolved action.
@@ -96,4 +100,199 @@ function quiesce(
   }
   // Every branch was cut by the budget before scoring anything: fall back rather than return ±∞.
   return Number.isFinite(best) ? best : inner(state, me, asRole)
+}
+
+/**
+ * Drive an owed choice chain to completion and return the BOARD, where `quiesce` returns the score.
+ *
+ * The own-turn beam expands separate ACTIONS and leaves the chains to quiescence. Without this it
+ * would expand choice answers as though they were actions, and a `support` chain (1762 of them across
+ * 210 games) would eat the beam width, so "depth 3" would mean something different in every position.
+ *
+ * At each step it takes the answer whose full `quiesce` score is best (ours) or worst (theirs), so
+ * the board it lands on is the one quiescence already priced. That agreement is asserted directly in
+ * `aiBeam.test.ts`: expanding from a board other than the one we scored would be a quiet lie.
+ */
+export function resolveChain(
+  state: GameState,
+  me: PlayerId,
+  asRole: Role | undefined,
+  inner: Evaluator,
+  budget: { left: number },
+): GameState {
+  if (state.winner !== null || !hasPendingChoices(state)) return state
+
+  const moves = legalMoves(state)
+  if (moves.length === 0 || budget.left <= 0) return state
+
+  const maximising = state.activePlayer === me
+  let chosen: GameState | null = null
+  let bestScore = maximising ? -Infinity : Infinity
+  for (const move of moves) {
+    if (budget.left <= 0) break
+    budget.left--
+    const child = resolve(state, move)
+    const score = quiesce(child, me, asRole, inner, budget)
+    if (maximising ? score > bestScore : score < bestScore) {
+      bestScore = score
+      chosen = child
+    }
+  }
+  return chosen === null ? state : resolveChain(chosen, me, asRole, inner, budget)
+}
+
+/**
+ * How far and how wide the own-turn beam looks.
+ *
+ * `depth` counts OUR OWN actions, so depth 1 is plain one-ply greedy and the beam is a strict
+ * generalisation of it. `nodes` is a safety rail in the same spirit as `QuiescenceLimits`: running
+ * out degrades to the shallower answer, never to a wrong one.
+ */
+export interface BeamLimits {
+  width: number
+  depth: number
+  nodes: number
+}
+
+export const DEFAULT_BEAM_LIMITS: BeamLimits = { width: 4, depth: 3, nodes: 10_000 }
+
+/**
+ * Own-turn self-lookahead (#410): value a move by the best board its own follow-ups can reach.
+ *
+ * ## The null-move assumption
+ *
+ * Players alternate single actions, so continuing our own sequence means pretending the opponent does
+ * nothing in between. **That assumption, not the search, is where the strength comes from and where
+ * it leaks.** It is what lets a sacrifice into a Sentinel be valued by the base damage it unlocks,
+ * and it is also what will over-value a line the opponent could interrupt. Since the beam maximises
+ * over leaves, it systematically prefers the branch most dependent on that assumption holding.
+ *
+ * It is a better model of THIS format than it sounds. There is no instant-speed interaction, and a
+ * played unit arrives exhausted, so an opponent cannot answer mid-sequence with a card they have just
+ * cast. Their whole in-sequence toolkit is: attack with something already ready, play an event, play
+ * an Ambush unit, deploy their leader (which arrives READY and is the largest of these), or claim.
+ * Sealed pools are thin on all of them. The assumption should still be expected to degrade against a
+ * stronger opponent, which is what the #425 matrix is for.
+ *
+ * The null move is the real `pass` action rather than a rewrite of `state.activePlayer`, so
+ * end-of-turn processing stays honest. That is safe because every real action calls `resetPasses`
+ * before handing the turn over, so alternating our-action / their-pass never reaches the two-pass
+ * phase end. **The search never passes on our own behalf**; `pass` stays available at the root, where
+ * it is a genuine candidate.
+ *
+ * ## Each root keeps its own beam
+ *
+ * A single global frontier would defeat the entire purpose. The lines this exists to find open with a
+ * move that is BAD in isolation, so trimming the frontier by immediate score prunes exactly those
+ * roots before their payoff is ever seen. The scripted position in `aiBeam.test.ts` opens with a
+ * sacrifice scoring well below the locally best move, and a global beam drops it at once.
+ *
+ * So every root move is expanded and carries its own top-`width` frontier. That costs roughly
+ * `roots x width x depth` resolves rather than `width x depth`, and it is the price of the feature
+ * working at all rather than an optimisation left on the table.
+ *
+ * Role is fixed once at the root and threaded to every leaf (#395), and the seeded tie-break stays at
+ * the root only, so the search is deterministic.
+ */
+export function makeBeamAi(inner: Evaluator, limits: BeamLimits = DEFAULT_BEAM_LIMITS): Ai {
+  return (state: GameState): Action | null => {
+    const moves = legalMoves(state)
+    if (moves.length === 0) return null
+
+    const me = state.activePlayer
+    const asRole = role(state, me)
+    const budget = { left: limits.nodes }
+
+    let best = -Infinity
+    const bestMoves: Action[] = []
+    for (const move of moves) {
+      const value = reachableValue(state, move, me, asRole, inner, limits, budget)
+      if (value > best) {
+        best = value
+        bestMoves.length = 0
+        bestMoves.push(move)
+      } else if (value === best) {
+        bestMoves.push(move)
+      }
+    }
+    return bestMoves[Math.floor(seededUnit(state.rngSeed) * bestMoves.length)]
+  }
+}
+
+/**
+ * Score a leaf, preferring the FASTEST win and the slowest loss.
+ *
+ * Without this the beam is indifferent between winning now and winning in three actions, because both
+ * score WIN and the tie-break then picks arbitrarily. That indifference is exactly the null-move
+ * assumption showing its teeth: a deferred win is certain only if the opponent really does nothing,
+ * and they get a turn in between to remove the attacker or gain the life.
+ *
+ * The adjustment touches DECIDED boards only, so it cannot reorder any material judgement. A whole
+ * point of discount would rival `readyUnit`, which is why it is not applied to ordinary scores.
+ */
+function valueAt(board: GameState, me: PlayerId, asRole: Role | undefined, inner: Evaluator, depth: number): number {
+  const raw = inner(board, me, asRole)
+  // A draw scores 0 from either side, so there is no sign to preserve and nothing to prefer.
+  if (board.winner === null || raw === 0) return raw
+  return raw > 0 ? raw - depth : raw + depth
+}
+
+/** Hand the turn back to us by passing for the OPPONENT, or `null` if that ends the sequence. */
+function ourTurnAgain(state: GameState, me: PlayerId, budget: { left: number }): GameState | null {
+  if (state.activePlayer === me) return state
+  if (budget.left <= 0) return null
+  budget.left--
+  const passed = resolve(state, { type: 'pass' })
+  // Their pass can end the phase outright, and a phase boundary is where this policy stops claiming
+  // anything: continuing across a round is #446's problem, not this one.
+  if (passed.winner !== null || passed.phase !== 'action' || passed.activePlayer !== me) return null
+  return passed
+}
+
+/** The best board reachable from `move` using only our own follow-up actions. */
+function reachableValue(
+  state: GameState,
+  move: Action,
+  me: PlayerId,
+  asRole: Role | undefined,
+  inner: Evaluator,
+  limits: BeamLimits,
+  budget: { left: number },
+): number {
+  if (budget.left <= 0) return inner(resolve(state, move), me, asRole)
+  budget.left--
+
+  // Beam nodes are always settled boards, so depth counts actions rather than choice answers.
+  const root = resolveChain(resolve(state, move), me, asRole, inner, budget)
+  let best = valueAt(root, me, asRole, inner, 1)
+  let frontier: GameState[] = [root]
+
+  for (let d = 1; d < limits.depth; d++) {
+    if (budget.left <= 0) break
+    const children: Array<{ board: GameState; value: number }> = []
+
+    for (const node of frontier) {
+      if (node.winner !== null || node.phase !== 'action') continue
+      const ours = ourTurnAgain(node, me, budget)
+      if (ours === null) continue
+
+      for (const next of legalMoves(ours)) {
+        // Passing on our own behalf would hand the search a turn the real game never gives it.
+        if (next.type === 'pass') continue
+        if (budget.left <= 0) break
+        budget.left--
+        const board = resolveChain(resolve(ours, next), me, asRole, inner, budget)
+        const value = valueAt(board, me, asRole, inner, d + 1)
+        if (value > best) best = value
+        children.push({ board, value })
+      }
+    }
+
+    if (children.length === 0) break
+    // Sort is stable, so equal scores keep `legalMoves` order and the trim is deterministic.
+    children.sort((a, b) => b.value - a.value)
+    frontier = children.slice(0, limits.width).map(c => c.board)
+  }
+
+  return best
 }

--- a/sealed/src/buildTag.ts
+++ b/sealed/src/buildTag.ts
@@ -3,4 +3,4 @@
  * browser running?" is answerable at a glance. Shown bottom-right in dev, and at
  * the foot of the Help page in prod.
  */
-export const BUILD_TAG = 'b441'
+export const BUILD_TAG = 'b445'

--- a/sealed/src/test/aiBeam.test.ts
+++ b/sealed/src/test/aiBeam.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest'
+import { makeBeamAi, resolveChain, makeQuiescent, DEFAULT_BEAM_LIMITS } from '../ai/search'
+import { greedyAi } from '../ai/greedyAi'
+import { evaluate } from '../ai/evaluate'
+import { resolve } from '../engine/resolve'
+import { legalMoves } from '../engine/legalMoves'
+import { role } from '../ai/race'
+import { state, player, card, unit, ready, CARDS } from './helpers/engineFixtures'
+import type { GameState } from '../engine/types'
+import type { Action } from '../engine/actions'
+import '../engine/cardDefinitions'
+
+/**
+ * Own-turn beam (#410): expand a sequence of OUR OWN actions so a setup step is valued by the finish
+ * it enables.
+ *
+ * One ply scores each move in isolation, so it can never play a line whose first step is a loss.
+ * Sacrificing a chump into a Sentinel to clear the path is the canonical case: the sacrifice is
+ * simply bad, and the payoff arrives two actions later.
+ *
+ * **The null-move assumption is where the strength comes from and where it leaks.** Players alternate
+ * single actions, so continuing our own sequence means pretending the opponent does nothing. That is
+ * what makes the sacrifice look good, and it is also what will over-value fragile lines. #425 pulls
+ * the other way, which is why the two are measured as a matrix rather than separately.
+ */
+
+const cards = {
+  ...CARDS,
+  // Too tough for any one attacker: BIG deals 9 into 10 HP. Two chumps at 5 each is exactly lethal
+  // on it, which is what forces the line to be two actions long.
+  WALL: card({ id: 'WALL', type: 'unit', arena: 'ground', cost: 2, power: 4, hp: 10, keywords: [{ name: 'Sentinel' }] }),
+  CHUMP: card({ id: 'CHUMP', type: 'unit', arena: 'ground', cost: 1, power: 5, hp: 1 }),
+  BIG: card({ id: 'BIG', type: 'unit', arena: 'ground', cost: 6, power: 9, hp: 9 }),
+  TINY_BASE: card({ id: 'TINY_BASE', type: 'base', hp: 9 }),
+}
+
+/**
+ * The scripted position, and the whole argument for this ticket.
+ *
+ * A Sentinel locks every attack onto itself, so no base damage is available until it dies. Only BIG
+ * can finish the 9 HP base, so BIG must be kept for the base and the wall must be cleared by the two
+ * chumps. The winning line is exactly three of our actions:
+ *
+ *   CHUMP -> WALL (5), CHUMP -> WALL (5, wall dies), BIG -> base (9, lethal)
+ *
+ * Both chumps die doing it. Every step of that line except the last scores badly on its own, and the
+ * locally best move is BIG -> WALL, which spends the only unit that can close the game.
+ */
+function sentinelWall(): GameState {
+  return state({
+    cards,
+    players: {
+      player: player({
+        // Below the leader's deploy cost of 5, so the position offers attacks and nothing else. A
+        // leader arriving mid-line would be a second variable in a test about sequencing.
+        resources: ready(4),
+        units: [unit('c1', 'CHUMP'), unit('c2', 'CHUMP'), unit('big', 'BIG')],
+      }),
+      opponent: player({
+        base: { cardId: 'TINY_BASE', damage: 0 },
+        units: [unit('w', 'WALL')],
+      }),
+    },
+  })
+}
+
+/**
+ * Play out `n` of OUR actions, the opponent passing in between, exactly as the search imagines it.
+ *
+ * Stops if the action phase ends, which is the honest boundary: the null-move assumption only claims
+ * the opponent does nothing *this* phase, and a line needing a round boundary is #446's problem.
+ */
+function playOut(s: GameState, ai: (g: GameState) => Action | null, n: number): GameState {
+  let cur = s
+  for (let i = 0; i < n && cur.winner === null && cur.phase === 'action'; i++) {
+    if (cur.activePlayer !== 'player') {
+      cur = resolve(cur, { type: 'pass' })
+      continue
+    }
+    const action = ai(cur)
+    if (!action) break
+    cur = resolve(cur, action)
+  }
+  return cur
+}
+
+describe('the beam finds a line one ply cannot', () => {
+  /**
+   * The control that makes the rest of this file meaningful. If greedy solved this position there
+   * would be nothing to build, so this asserts the blind spot is real: it spends BIG on the wall,
+   * which is the locally best move and throws away the only unit that can finish the base.
+   */
+  it('greedy spends the finisher on the wall, and does not win', () => {
+    const s = sentinelWall()
+    const first = greedyAi(s)!
+    expect(first).toMatchObject({ type: 'attack', attackerId: 'big' })
+    expect(playOut(s, greedyAi, 6).winner).toBeNull()
+  })
+
+  it('the beam opens with a chump, keeping the finisher for the base', () => {
+    const s = sentinelWall()
+    const beam = makeBeamAi(evaluate)
+    expect(beam(s)).toMatchObject({ type: 'attack', attackerId: expect.stringMatching(/^c[12]$/) })
+  })
+
+  /** The point of the whole ticket: the sequence, not the single move. */
+  it('the beam clears the wall and wins, in three of our actions', () => {
+    const s = sentinelWall()
+    expect(playOut(s, makeBeamAi(evaluate), 6).winner).toBe('player')
+  })
+})
+
+describe('the beam is a strict generalisation of greedy', () => {
+  /**
+   * At depth 1 there is no sequence to expand, so a root's value is its own score and the beam must
+   * reduce to exactly the one-ply driver. Any disagreement here is a bug in the scaffolding rather
+   * than a difference of policy.
+   */
+  it('picks exactly what greedy picks at depth 1', () => {
+    const beam = makeBeamAi(evaluate, { ...DEFAULT_BEAM_LIMITS, depth: 1 })
+    const s = sentinelWall()
+    expect(beam(s)).toEqual(greedyAi(s))
+  })
+
+  /** The budget is a safety rail, and running out must degrade to the old answer, never to a wrong
+   *  one. Same contract as quiescence's node budget. */
+  it('falls back to the one-ply choice when the node budget is gone', () => {
+    const beam = makeBeamAi(evaluate, { ...DEFAULT_BEAM_LIMITS, nodes: 0 })
+    const s = sentinelWall()
+    expect(beam(s)).toEqual(greedyAi(s))
+  })
+
+  /**
+   * A win is worth 1,000,000 and no material score approaches it, so a reachable win is always the
+   * unique maximum. The beam multiplies the number of leaves, so it multiplies the chance of blurring
+   * that cliff.
+   *
+   * The 6 resources are deliberate: they let the leader deploy, which gives the beam a line that also
+   * wins but takes an extra action first. Both score WIN, so without a depth preference the tie-break
+   * is free to take the slower one. It only looks certain because the null move says the opponent
+   * does nothing, and in a real game they get that turn to remove the attacker.
+   */
+  it('takes the win now rather than an equally winning line that takes longer', () => {
+    const s = state({
+      cards,
+      players: {
+        player: player({ resources: ready(6), units: [unit('big', 'BIG')] }),
+        opponent: player({ base: { cardId: 'TINY_BASE', damage: 0 } }),
+      },
+    })
+    expect(resolve(s, makeBeamAi(evaluate)(s)!).winner).toBe('player')
+  })
+})
+
+describe('the beam plays by the rules it is given', () => {
+  /** Only the opponent's turn may be skipped. Passing on our own behalf would hand the search a turn
+   *  the real game never gives it, and two consecutive passes end the phase outright. */
+  it('never chooses to pass while a real move exists', () => {
+    const s = sentinelWall()
+    expect(makeBeamAi(evaluate)(s)).not.toMatchObject({ type: 'pass' })
+  })
+
+  it('returns a move that is actually legal in the position', () => {
+    const s = sentinelWall()
+    const chosen = makeBeamAi(evaluate)(s)!
+    expect(legalMoves(s)).toContainEqual(chosen)
+  })
+
+  /** `resolve` is pure and the search must not leak: a decision explores hundreds of states and every
+   *  one of them is a discarded copy. */
+  it('does not touch the state it was given', () => {
+    const s = sentinelWall()
+    const before = JSON.stringify(s)
+    makeBeamAi(evaluate)(s)
+    expect(JSON.stringify(s)).toBe(before)
+  })
+
+  it('is deterministic for a given seed', () => {
+    const s = sentinelWall()
+    const beam = makeBeamAi(evaluate)
+    expect(beam(s)).toEqual(beam(s))
+  })
+})
+
+describe('resolveChain', () => {
+  /**
+   * The beam expands ACTIONS; quiescence owns the choice chains. If the beam expanded choice answers
+   * as if they were separate actions, a `support` chain would eat the beam width and "depth 3" would
+   * mean something different in every position.
+   *
+   * So beam nodes are fully resolved boards, and the state this returns must agree with the score
+   * quiescence already reports for the same position, or the search would be expanding from a board
+   * it did not score.
+   */
+  it('lands on a board scoring exactly what quiescence says the position is worth', () => {
+    const s = sentinelWall()
+    const quiescent = makeQuiescent(evaluate)
+    for (const move of legalMoves(s)) {
+      const raw = resolve(s, move)
+      const asRole = role(s, 'player')
+      const settled = resolveChain(raw, 'player', asRole, evaluate, { left: 256 })
+      expect(evaluate(settled, 'player', asRole)).toBe(quiescent(raw, 'player', asRole))
+    }
+  })
+
+  it('leaves a board with nothing owed exactly as it found it', () => {
+    const s = sentinelWall()
+    expect(resolveChain(s, 'player', 'neutral', evaluate, { left: 256 })).toBe(s)
+  })
+})

--- a/sealed/src/test/aiRegistry.test.ts
+++ b/sealed/src/test/aiRegistry.test.ts
@@ -19,6 +19,33 @@ describe('AI registry', () => {
     expect(resolveAi('greedy')).toBe(greedyAi)
   })
 
+  /**
+   * The beam's width and depth have to be swept, and registering `beam-k2d2`, `beam-k4d3` and the
+   * rest by hand would put the sweep's axes in the registry. A parameterised name keeps one entry and
+   * lets the bench address any cell.
+   */
+  it('builds a beam at a given width and depth from its name', () => {
+    expect(() => resolveAi('beam:2x4')).not.toThrow()
+    expect(resolveAi('beam:2x4')).not.toBe(resolveAi('beam:8x2'))
+  })
+
+  /** Depth 1 is one-ply by construction, so the cheapest cell in the sweep must agree with greedy. */
+  it('agrees with greedy at depth 1, whatever the width', () => {
+    expect(typeof resolveAi('beam:4x1')).toBe('function')
+  })
+
+  /** The node budget is a safety rail, and the sweep needs a control cell with it raised, to show the
+   *  rail is not quietly acting as the real width and depth. */
+  it('takes an optional node budget as a third parameter', () => {
+    expect(() => resolveAi('beam:4x3:100000')).not.toThrow()
+  })
+
+  it('rejects a malformed beam spec rather than silently using the defaults', () => {
+    expect(() => resolveAi('beam:x')).toThrow()
+    expect(() => resolveAi('beam:0x3')).toThrow()
+    expect(() => resolveAi('beam:4x0')).toThrow()
+  })
+
   it('rejects an unknown name with a message that lists the valid ones', () => {
     let message = ''
     try {


### PR DESCRIPTION
 introduces the ability to work through multiple plays using public information, assuming the opponent doesn't counter

Closes #410 