### PR TITLE
feat/sealed-bench-play-coverage 

### DIFF
--- a/sealed/docs/ai-benchmark.md
+++ b/sealed/docs/ai-benchmark.md
@@ -177,9 +177,69 @@ npm run bench --prefix sealed -- --sweep [--games N] [--seed N] [ai]
 ```
 
 `--games` is games *per deck* (default 5); `ai` defaults to `random`, which is fast and pokes card
-interactions broadly (the best bug-finder). It reports how many decks and games ran, how many cards
-were exercised, and any dropped game, writing each as a replayable fixture. A drop here is a
-**finding**, a hang or throw in some card, not a failure of the sweep.
+interactions broadly (the best bug-finder). It reports the coverage numbers below and any dropped
+game, writing each as a replayable fixture. A drop here is a **finding**, a hang or throw in some
+card, not a failure of the sweep.
+
+### Decked, drawn, played: three different claims
+
+A card being in a deck is availability, not evidence. It can sit in every deck of the sweep, never be
+drawn, and prove nothing about itself. The sweep therefore reports three numbers, and card
+implementation work rests on the third:
+
+- **cards decked**: deck-able cards the deck set includes. ASH's 264 cards are 18 leaders, 8 bases
+  and 238 deck-able, and the generated set includes all 238.
+- **cards drawn**: of those, how many reached a hand.
+- **cards played**: how many were actually played. Cards decked but never played are **listed by id**
+  rather than summarised, so a stubborn one can be chased.
+
+Leaders and bases are counted apart, because both are in play from the first turn. Folding them in
+would credit two free cards per deck. A leader is reported as deployed only when it actually
+deploys, which is the only way its deployed side runs.
+
+An uncovered card is **not** a failure and does not affect the exit code. It is a fact about what the
+run reached. Dropped games are the failure signal.
+
+### Several seeds beat a longer run
+
+`--seed` takes a list. Every deck plays `--games` games under each seed, and coverage is the
+**union** across them:
+
+```bash
+npm run bench --prefix sealed -- --sweep --games 5 --seed 42,43,44
+```
+
+This is the shape to use, because tail coverage is **seed-luck rather than run length**. One game a
+deck plays 207 of 238 cards (87%); five plays 237 (99.6%); and raising it to 40 still leaves one card
+on seed 42 while covering everything on seed 99. Five games across three seeds reaches **238 of 238
+in 630 games and about five seconds**, which is the sweep worth standardising on.
+
+Each seed is an independent chain, so adding one extends the evidence instead of reshuffling what the
+earlier seeds did, and the seed list is printed and reported so any result can be reproduced exactly.
+The deck set itself is generated once from the first seed: regenerating it per seed would change
+which cards are decked at all, and the union would no longer measure one pool.
+
+If a card still resists, chase that card rather than raising the counts. `uncovered` names it, sorted
+by set and then by collector number as a number, so `TS26_3` sorts before `TS26_10` rather than after
+it as a plain string sort would have it.
+
+### How coverage is measured
+
+`bench/playCoverage.ts` reads **state** rather than interpreting actions. A card reaches play by
+several routes (from hand, from the resource zone, from the deck, discounted from hand), several of
+them arriving as an `acceptChoice` whose fields mean different things per pending choice. A card
+sitting in play got there by being played, whichever route it took, so state is the stable signal.
+
+Two cases need the action instead, because they leave no trace between moves: an **event**, which
+never persists, and anything that **enters and leaves play inside a single action**, since coverage
+is observed between actions. A card whose defeat is a *choice* is not that case: answering the choice
+is its own action, so there is an observation point while the card is still in play.
+
+**Where it is unsure it does not credit the card.** Under-counting yields a false "uncovered", which
+is visible and gets investigated. Over-counting yields a false "covered", which is a silent lie.
+
+Tracking is off by default and the sweep turns it on: it costs a set-union per step, and the AI
+benchmark plays hundreds of thousands of games where the answer is never read.
 
 The decks come from `deckgen/generateDeck.ts` (a reusable primitive that builds one legal,
 penalty-free, realistically curved deck for a leader, respecting rarity mix and aspect balance, see

--- a/sealed/docs/operations.md
+++ b/sealed/docs/operations.md
@@ -29,8 +29,12 @@ card in the pool, fuzzing the whole set for hangs and throws (each dropped game 
 replayable fixture):
 
 ```bash
-npm run bench --prefix sealed -- --sweep --games 20 --seed 42
+npm run bench --prefix sealed -- --sweep --games 5 --seed 42,43,44
 ```
+
+`--seed` takes a list, and coverage is the union across them. Five games a deck on three seeds plays
+every card in the pool in a few seconds; one long single-seed run does not, because the last card or
+two is seed-luck rather than run length.
 
 And a **generalisation diagnostic** (`--generalise`) that plays one AI against another across the
 coverage decks and reports the per-deck win rate (weakest first), to see where an AI is weak and

--- a/sealed/src/bench/main.ts
+++ b/sealed/src/bench/main.ts
@@ -42,6 +42,8 @@ interface Args {
   games: number
   gamesSet: boolean
   seed: number
+  /** Every seed given. Only the sweep uses more than the first. */
+  seeds: number[]
   sweep: boolean
   generalise: boolean
   matrix: boolean
@@ -64,6 +66,7 @@ function parseArgs(argv: string[]): Args {
   let games = 100
   let gamesSet = false
   let seed = 1
+  let seeds = [1]
   let sweep = false
   let generalise = false
   let matrix = false
@@ -76,7 +79,9 @@ function parseArgs(argv: string[]): Args {
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
     if (arg === '--games') { games = Number(argv[++i]); gamesSet = true }
-    else if (arg === '--seed') seed = Number(argv[++i])
+    // `--seed 1,2,3` runs the sweep under each seed and unions the coverage. Other modes take the
+    // first, so a list is harmless rather than an error where it has no meaning.
+    else if (arg === '--seed') { seeds = argv[++i].split(',').map(Number); seed = seeds[0] }
     else if (arg === '--sweep') sweep = true
     else if (arg === '--generalise') generalise = true
     else if (arg === '--matrix') matrix = true
@@ -90,10 +95,10 @@ function parseArgs(argv: string[]): Args {
     else positional.push(arg)
   }
   if (!Number.isFinite(games) || games < 1) throw new Error(`--games must be a positive integer`)
-  if (!Number.isFinite(seed)) throw new Error(`--seed must be a number`)
+  if (!seeds.every(Number.isFinite) || seeds.length === 0) throw new Error('--seed must be a number, or a comma-separated list of numbers')
   if (depth !== undefined && (!Number.isFinite(depth) || depth < 1)) throw new Error('--depth must be a positive integer')
   if (triage && positional.length === 0) throw new Error('--triage needs at least one set code, e.g. --triage LAW SEC')
-  return { games, gamesSet, seed, sweep, generalise, matrix, decisions, terms, lethal, depth, matchups, triage, sets: positional.map(s => s.toUpperCase()), aiExplicit: positional.length > 0, aiA: positional[0] ?? 'random', aiB: positional[1] ?? 'random' }
+  return { games, gamesSet, seed, seeds, sweep, generalise, matrix, decisions, terms, lethal, depth, matchups, triage, sets: positional.map(s => s.toUpperCase()), aiExplicit: positional.length > 0, aiA: positional[0] ?? 'random', aiB: positional[1] ?? 'random' }
 }
 
 const pct = (x: number): string => `${(x * 100).toFixed(1)}%`
@@ -131,14 +136,27 @@ function formatSweep(report: SweepReport, wallMs: number, aiName: string): strin
   const lines = [
     '',
     `dmgCtrl coverage sweep  (engine ${report.commitId})`,
-    `${report.decks} decks × ${report.gamesPerDeck} games   ${aiName} mirror`,
+    `${report.decks} decks × ${report.gamesPerDeck} games × ${report.seeds.length} seed(s)   ${aiName} mirror`,
     '',
+    row('seeds', report.seeds.join(', ')),
     row('total games', `${report.totalGames}`),
     row('completed / dropped', `${report.completed} / ${report.dropped}`),
-    row('cards exercised', `${report.cardsExercised}`),
+    row('cards decked', `${report.cardsDecked}`),
+    row('cards drawn', `${report.cardsDrawn}`),
+    row('cards played', `${report.cardsPlayed}  (${pct(report.cardsPlayed / Math.max(1, report.cardsDecked))} of decked)`),
+    row('leaders / deployed', `${report.leaders} / ${report.leadersDeployed}`),
+    row('bases', `${report.bases}`),
     row('wall clock', `${(wallMs / 1000).toFixed(1)}s`),
     '',
   ]
+  if (report.uncovered.length > 0) {
+    // Not a failure: a card the run never reached is a fact about the run, and the card tickets
+    // assert against this list themselves.
+    lines.push(`  ${report.uncovered.length} card(s) decked but never played:`)
+    for (const id of report.uncovered.slice(0, 40)) lines.push(`    ${id}`)
+    if (report.uncovered.length > 40) lines.push(`    ... and ${report.uncovered.length - 40} more`)
+    lines.push('')
+  }
   if (report.dropped > 0) {
     lines.push(`  ⚠ ${report.dropped} game(s) dropped across the pool:`)
     for (const f of report.failures.slice(0, 40)) lines.push(`    ${f.deck}  seed ${f.seed}  ${f.reason}`)
@@ -155,7 +173,7 @@ function runSweepMode(args: Args): void {
   const start = Date.now()
   let report: SweepReport
   try {
-    report = runSweep({ gamesPerDeck, seed: args.seed, aiName: args.aiA })
+    report = runSweep({ gamesPerDeck, seeds: args.seeds, aiName: args.aiA })
   } catch (err) {
     console.error(`bench: ${(err as Error).message}`)
     process.exit(2)

--- a/sealed/src/bench/playCoverage.ts
+++ b/sealed/src/bench/playCoverage.ts
@@ -1,0 +1,106 @@
+import type { Action } from '../engine/actions'
+import type { GameState, PlayerId } from '../engine/types'
+
+/**
+ * Per-card play coverage: which cards a run actually PLAYED, as distinct from which cards sat in a
+ * deck it never drew from.
+ *
+ * Card-implementation tickets assert "every card in this group was played at least once during the
+ * run". Counting decks cannot back that claim: a card can be in every deck of a sweep, never be
+ * drawn, and still look covered.
+ *
+ * ## Why this reads state rather than actions
+ *
+ * A card reaches play by several routes: played from hand, from the resource zone (The Armorer),
+ * from the deck (Clan Wren Loyalist, Admiral Ackbar), or discounted from hand (Crix Madine). Several
+ * arrive as an `acceptChoice` whose `handIndex` or `deckIndex` means something different per pending
+ * choice, so a mapping written against action shapes would have to know every choice kind and would
+ * rot as new ones land. A card sitting in play got there by being played, whichever route it took.
+ *
+ * Events are the exception: they never persist. They resolve to the discard pile, but so does a card
+ * discarded from hand, so the pile would over-credit. For events the `playEvent` action is the only
+ * unambiguous signal.
+ *
+ * ## It under-counts on purpose
+ *
+ * An event played through a choice rather than through `playEvent` is missed. That is the intended
+ * direction of error: under-counting yields a false "uncovered", which is visible and gets
+ * investigated, while over-counting yields a false "covered", which is the silent lie this exists to
+ * prevent.
+ */
+
+/**
+ * Order card ids the way a person reads them: set, then collector number as a NUMBER.
+ *
+ * A plain string sort puts `TS26_10` before `TS26_3`, because only some sets zero-pad. ASH does,
+ * which is why the flaw stays invisible until another set is in play.
+ */
+export function compareCardIds(a: string, b: string): number {
+  const parse = (id: string): [string, number] => {
+    const cut = id.lastIndexOf('_')
+    return cut === -1 ? [id, Number.NaN] : [id.slice(0, cut), Number(id.slice(cut + 1))]
+  }
+  const [setA, numA] = parse(a)
+  const [setB, numB] = parse(b)
+  if (setA !== setB) return setA < setB ? -1 : 1
+  // An unparseable number falls back to string order rather than to NaN, which would make the
+  // comparator inconsistent and the sort order arbitrary.
+  if (Number.isNaN(numA) || Number.isNaN(numB)) return a < b ? -1 : a > b ? 1 : 0
+  return numA - numB
+}
+
+export interface PlayCoverage {
+  /** Card ids seen in a hand: dealt, drawn, or returned there. */
+  drawn: Set<string>
+  /** Deck-card ids seen in play, or resolved as an event. Excludes leaders. */
+  played: Set<string>
+  /** Leader ids that actually deployed. Kept apart: a leader is in play from the first turn, so
+   *  folding it in would credit a free card per deck and hide whether the deployed side ever ran. */
+  leadersDeployed: Set<string>
+}
+
+const SEATS: readonly PlayerId[] = ['player', 'opponent']
+
+export function newCoverage(): PlayCoverage {
+  return { drawn: new Set(), played: new Set(), leadersDeployed: new Set() }
+}
+
+/** Fold everything visible in this position into the coverage. Idempotent, so it is safe per step. */
+export function observeState(cov: PlayCoverage, state: GameState): void {
+  for (const seat of SEATS) {
+    const p = state.players[seat]
+    for (const id of p.hand) cov.drawn.add(id)
+    for (const u of p.units) {
+      // A deployed leader lives in units[] with isLeader, which is what makes deployment observable
+      // here rather than needing the deployLeader action.
+      if (u.isLeader) cov.leadersDeployed.add(u.cardId)
+      else cov.played.add(u.cardId)
+      // Upgrades count either way, including those attached to a deployed leader.
+      for (const up of u.upgrades) cov.played.add(up.cardId)
+    }
+  }
+}
+
+/**
+ * Credit a card played straight from hand.
+ *
+ * Two cases need this rather than state observation:
+ *
+ * - **Events** never persist. They resolve to the discard, and so does a card discarded from hand,
+ *   so the pile would over-credit.
+ * - **Anything that enters and leaves play within a single action.** Coverage is observed between
+ *   actions, so a card that is played and defeated inside one `resolve` is never seen in `units[]`.
+ *   A card whose defeat is a *choice* is not this case, since answering the choice is its own action
+ *   and leaves an observation point while the card is still in play.
+ *
+ * Deliberately narrow. `resourceCard` and `setupResource` carry a `handIndex` of exactly the same
+ * shape and are not plays, so anything else is ignored rather than guessed at.
+ */
+const PLAYS_FROM_HAND = new Set(['playUnit', 'playUpgrade', 'playEvent'])
+
+export function observeAction(cov: PlayCoverage, state: GameState, action: Action): void {
+  if (!PLAYS_FROM_HAND.has(action.type)) return
+  const { handIndex } = action as Extract<Action, { handIndex: number }>
+  const id = state.players[state.activePlayer].hand[handIndex]
+  if (id) cov.played.add(id)
+}

--- a/sealed/src/bench/selfPlay.ts
+++ b/sealed/src/bench/selfPlay.ts
@@ -6,6 +6,7 @@ import { initGame } from '../engine/initGame'
 import { resolve } from '../engine/resolve'
 import { seededShuffle, nextSeed } from '../engine/rng'
 import { setupAi } from '../ai/setupAi'
+import { newCoverage, observeAction, observeState } from './playCoverage'
 
 /** Why a game was abandoned instead of counted. Each is a distinct engine-defect signature. */
 export type DropReason = 'nonterminating' | 'timeout' | 'stuck' | 'threw'
@@ -31,6 +32,15 @@ export interface GameResult {
   durationMs: number
   /** The moves played, retained so a dropped game can be replayed. */
   moves: MoveRecord[]
+  /**
+   * Per-card play coverage, empty unless `trackCoverage` was set. Deck-card ids only: leaders are
+   * reported in `leadersDeployed`, since they are in play from the first turn.
+   */
+  cardsPlayed: string[]
+  /** Card ids that reached a hand. A card decked but never drawn appears in neither list. */
+  cardsDrawn: string[]
+  /** Leader ids that deployed, which is the only way a leader's deployed side runs. */
+  leadersDeployed: string[]
   /**
    * The starting position, so a dropped game becomes a replayable fixture ({ initialState, moves }).
    * `runBench` clears it for completed games to bound memory over a long run.
@@ -62,6 +72,12 @@ export interface PlayGameOptions {
    * @deprecated wall-clock time no longer affects the outcome; use `stepCeiling`.
    */
   timeoutMs?: number
+  /**
+   * Track which cards were drawn and played. Off by default: it costs a set-union per step, and the
+   * AI benchmark plays hundreds of thousands of games where the answer is never read. The coverage
+   * sweep turns it on.
+   */
+  trackCoverage?: boolean
 }
 
 /**
@@ -107,6 +123,8 @@ export function playGame(opts: PlayGameOptions): GameResult {
   let dropReason: DropReason | null = null
   let steps = 0
 
+  const coverage = opts.trackCoverage ? newCoverage() : null
+
   try {
     while (state.winner === null) {
       if (steps >= stepCeiling) {
@@ -114,6 +132,7 @@ export function playGame(opts: PlayGameOptions): GameResult {
         dropReason = 'nonterminating'
         break
       }
+      if (coverage) observeState(coverage, state)
       const active = state.activePlayer
       const ai = active === 'player' ? opts.aiPlayer : opts.aiOpponent
       const action = setupAi(state) ?? ai(state)
@@ -122,6 +141,8 @@ export function playGame(opts: PlayGameOptions): GameResult {
         dropReason = 'stuck'
         break
       }
+      // Read the action against the state it was chosen in: a hand index means nothing afterwards.
+      if (coverage) observeAction(coverage, state, action)
       moves.push({ by: active, action })
       state = resolve(state, action)
       steps++
@@ -130,6 +151,10 @@ export function playGame(opts: PlayGameOptions): GameResult {
     status = 'dropped'
     dropReason = 'threw'
   }
+
+  // The loop observes before acting, so the final position has not been seen yet. A unit played by
+  // the winning move would otherwise be missed.
+  if (coverage) observeState(coverage, state)
 
   const baseDamage: Record<PlayerId, number> = {
     player: state.players.player.base.damage,
@@ -149,5 +174,8 @@ export function playGame(opts: PlayGameOptions): GameResult {
     durationMs: performance.now() - start,
     moves,
     initialState,
+    cardsPlayed: coverage ? [...coverage.played] : [],
+    cardsDrawn: coverage ? [...coverage.drawn] : [],
+    leadersDeployed: coverage ? [...coverage.leadersDeployed] : [],
   }
 }

--- a/sealed/src/bench/sweep.ts
+++ b/sealed/src/bench/sweep.ts
@@ -6,6 +6,7 @@ import { nextSeed } from '../engine/rng'
 import { COMMIT_ID } from '../buildIdentity'
 import { resolveAi } from '../ai/registry'
 import { buildCoverageDecks } from './coverageDecks'
+import { compareCardIds } from './playCoverage'
 import { playGame } from './selfPlay'
 import type { DropReason, GameResult } from './selfPlay'
 
@@ -20,7 +21,12 @@ const POOL = ashSet as unknown as SwuCard[]
 
 export interface SweepConfig {
   gamesPerDeck: number
-  seed: number
+  /**
+   * One or more run seeds. Every deck plays `gamesPerDeck` games under each, and coverage is the
+   * UNION across them. Tail coverage is seed-luck rather than run length (a card unplayed on one
+   * seed is played on the next), so several short seeds are better evidence than one long run.
+   */
+  seeds: number[]
   aiName?: string
   stepCeiling?: number
   timeoutMs?: number
@@ -37,66 +43,114 @@ export interface SweepReport {
   commitId: string
   decks: number
   gamesPerDeck: number
+  /** The seeds this run used, so it can be reproduced exactly. */
+  seeds: number[]
   totalGames: number
   completed: number
   dropped: number
-  /** Distinct card ids exercised across the deck set (leaders and bases included). */
-  cardsExercised: number
+  /**
+   * Deck-able card ids put into a deck. This is availability, NOT evidence: a card can be in every
+   * deck of the sweep and never be drawn. Leaders and bases are counted separately below.
+   */
+  cardsDecked: number
+  /** Decked cards that reached a hand at least once. */
+  cardsDrawn: number
+  /** Decked cards actually played. This is the number a coverage claim rests on. */
+  cardsPlayed: number
+  /** Decked but never played, named rather than summarised so a stubborn card can be chased. */
+  uncovered: string[]
+  /** Distinct leaders across the deck set, and how many of them actually deployed. */
+  leaders: number
+  leadersDeployed: number
+  /** Distinct bases across the deck set. A base is in play from the first turn, so it is never
+   *  "played"; it is reported for completeness rather than as coverage. */
+  bases: number
   failures: SweepFailure[]
   /** The dropped games, kept whole so they can be written out as replayable fixtures. */
   droppedGames: GameResult[]
 }
 
 export function runSweep(config: SweepConfig): SweepReport {
-  const { decks } = buildCoverageDecks(POOL, config.seed)
+  // The deck set is generated once, from the first seed. Regenerating it per seed would change
+  // which cards are decked at all, so `cardsDecked` would move between seeds and the union would
+  // no longer be measuring the same pool. Only the GAME seeds vary.
+  const { decks } = buildCoverageDecks(POOL, config.seeds[0])
   const cardDb = buildCardDb(POOL)
   const ai = resolveAi(config.aiName ?? 'random')
 
-  let seed = config.seed
   let completed = 0
   let dropped = 0
   let gameIndex = 0
   const failures: SweepFailure[] = []
   const droppedGames: GameResult[] = []
-  const exercised = new Set<string>()
+  // Availability, by card type. Leaders and bases are separated here rather than at the end,
+  // because a leader is in play from the first turn and would otherwise read as free coverage.
+  const decked = new Set<string>()
+  const leaders = new Set<string>()
+  const bases = new Set<string>()
+  // Evidence: what the games actually reached.
+  const drawn = new Set<string>()
+  const played = new Set<string>()
+  const deployed = new Set<string>()
 
-  for (const deck of decks) {
-    exercised.add(deck.leader)
-    exercised.add(deck.base)
-    for (const entry of deck.cards) exercised.add(entry.id)
+  // Each seed is an independent chain, so a run is reproducible from its seed list alone and adding
+  // a seed extends the evidence rather than reshuffling what the earlier ones did.
+  for (const baseSeed of config.seeds) {
+    let seed = baseSeed
+    for (const deck of decks) {
+      leaders.add(deck.leader)
+      bases.add(deck.base)
+      for (const entry of deck.cards) decked.add(entry.id)
 
-    for (let g = 0; g < config.gamesPerDeck; g++) {
-      seed = nextSeed(seed)
-      const result = playGame({
-        deckPlayer: deck,
-        deckOpponent: deck,
-        cardDb,
-        aiPlayer: ai,
-        aiOpponent: ai,
-        seed,
-        firstPlayer: g % 2 === 0 ? 'player' : 'opponent',
-        stepCeiling: config.stepCeiling,
-        timeoutMs: config.timeoutMs,
-      })
-      if (result.status === 'dropped') {
-        dropped++
-        failures.push({ deck: deck.name, gameIndex, seed: result.seed, reason: result.dropReason! })
-        droppedGames.push(result)
-      } else {
-        completed++
+      for (let g = 0; g < config.gamesPerDeck; g++) {
+        seed = nextSeed(seed)
+        const result = playGame({
+          deckPlayer: deck,
+          deckOpponent: deck,
+          cardDb,
+          aiPlayer: ai,
+          aiOpponent: ai,
+          seed,
+          firstPlayer: g % 2 === 0 ? 'player' : 'opponent',
+          stepCeiling: config.stepCeiling,
+          timeoutMs: config.timeoutMs,
+          trackCoverage: true,
+        })
+        for (const id of result.cardsDrawn) drawn.add(id)
+        for (const id of result.cardsPlayed) played.add(id)
+        for (const id of result.leadersDeployed) deployed.add(id)
+        if (result.status === 'dropped') {
+          dropped++
+          failures.push({ deck: deck.name, gameIndex, seed: result.seed, reason: result.dropReason! })
+          droppedGames.push(result)
+        } else {
+          completed++
+        }
+        gameIndex++
       }
-      gameIndex++
     }
   }
+
+  // Intersect with what was decked: play also surfaces tokens (Shield, Experience, Mandalorian),
+  // which are created rather than decked and are not part of pool coverage.
+  const deckedPlayed = [...decked].filter(id => played.has(id))
+  const deckedDrawn = [...decked].filter(id => drawn.has(id))
 
   return {
     commitId: COMMIT_ID,
     decks: decks.length,
     gamesPerDeck: config.gamesPerDeck,
+    seeds: [...config.seeds],
     totalGames: gameIndex,
     completed,
     dropped,
-    cardsExercised: exercised.size,
+    cardsDecked: decked.size,
+    cardsDrawn: deckedDrawn.length,
+    cardsPlayed: deckedPlayed.length,
+    uncovered: [...decked].filter(id => !played.has(id)).sort(compareCardIds),
+    leaders: leaders.size,
+    leadersDeployed: [...leaders].filter(id => deployed.has(id)).length,
+    bases: bases.size,
     failures,
     droppedGames,
   }

--- a/sealed/src/test/benchPlayCoverage.test.ts
+++ b/sealed/src/test/benchPlayCoverage.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect } from 'vitest'
+import { compareCardIds, newCoverage, observeAction, observeState } from '../bench/playCoverage'
+import { playGame } from '../bench/selfPlay'
+import { benchInputs } from '../bench/decks'
+import { randomAi } from '../ai/randomAi'
+import { state, player, unit } from './helpers/engineFixtures'
+
+/**
+ * Per-card play coverage: which cards a run actually PLAYED, as opposed to which cards sat in a deck.
+ *
+ * The distinction is the whole point. A card can be in the deck of every game in a sweep, never be
+ * drawn, and still look covered if you count decks. Card-implementation tickets assert "every card
+ * in my group was played at least once", so a meter that cannot tell those apart makes the assertion
+ * meaningless.
+ *
+ * The tracker reads STATE rather than interpreting actions, because a card reaches play by several
+ * routes (from hand, from resources, from deck, discounted from hand) and a mapping written against
+ * action shapes would have to know every pending-choice kind. A card sitting in play got there by
+ * being played, whichever route it took.
+ *
+ * **Where it is unsure it does not credit the card.** Under-counting produces a false "uncovered",
+ * which is visible and gets investigated. Over-counting produces a false "covered", which is the
+ * silent lie this exists to prevent.
+ */
+
+describe('coverage tracker: what counts as drawn', () => {
+  it('counts a card held in hand', () => {
+    const cov = newCoverage()
+    observeState(cov, state({ players: { player: player({ hand: ['TST_U1'] }), opponent: player() } }))
+    expect([...cov.drawn]).toEqual(['TST_U1'])
+  })
+
+  it('counts both seats, since a sweep plays the same deck on each side', () => {
+    const cov = newCoverage()
+    observeState(cov, state({
+      players: { player: player({ hand: ['TST_U1'] }), opponent: player({ hand: ['TST_U2'] }) },
+    }))
+    expect([...cov.drawn].sort()).toEqual(['TST_U1', 'TST_U2'])
+  })
+
+  it('does NOT count a card still in the deck', () => {
+    // The defect this ticket exists to fix: decked is not drawn.
+    const cov = newCoverage()
+    observeState(cov, state({ players: { player: player({ deck: ['TST_U3'] }), opponent: player() } }))
+    expect(cov.drawn.has('TST_U3')).toBe(false)
+    expect(cov.played.has('TST_U3')).toBe(false)
+  })
+
+  it('does not count a card that only ever sat in the resource zone', () => {
+    const cov = newCoverage()
+    observeState(cov, state({
+      players: { player: player({ resources: [{ cardId: 'TST_U4', exhausted: false }] }), opponent: player() },
+    }))
+    expect(cov.drawn.has('TST_U4')).toBe(false)
+    expect(cov.played.has('TST_U4')).toBe(false)
+  })
+})
+
+describe('coverage tracker: what counts as played', () => {
+  it('counts a unit in play', () => {
+    const cov = newCoverage()
+    observeState(cov, state({ players: { player: player({ units: [unit('u1', 'TST_U1')] }), opponent: player() } }))
+    expect(cov.played.has('TST_U1')).toBe(true)
+  })
+
+  it('counts an upgrade attached to a unit', () => {
+    const cov = newCoverage()
+    observeState(cov, state({
+      players: {
+        player: player({ units: [unit('u1', 'TST_U1', { upgrades: [{ cardId: 'TST_E1', owner: 'player' }] })] }),
+        opponent: player(),
+      },
+    }))
+    expect(cov.played.has('TST_E1')).toBe(true)
+  })
+
+  it('counts a card in play regardless of how it got there', () => {
+    // Played from hand, from resources (The Armorer), from deck (Clan Wren Loyalist) or discounted
+    // (Crix Madine) all look the same in state, which is exactly why state is the signal.
+    const cov = newCoverage()
+    observeState(cov, state({ players: { player: player({ units: [unit('u1', 'TST_U2')] }), opponent: player() } }))
+    expect(cov.played.has('TST_U2')).toBe(true)
+  })
+
+  it('does not count a card merely held in hand as played', () => {
+    const cov = newCoverage()
+    observeState(cov, state({ players: { player: player({ hand: ['TST_U1'] }), opponent: player() } }))
+    expect(cov.drawn.has('TST_U1')).toBe(true)
+    expect(cov.played.has('TST_U1')).toBe(false)
+  })
+
+  it('does not count a card in the discard pile, which cannot distinguish played from discarded', () => {
+    // An event resolves to the discard; so does a card discarded from hand. The pile would
+    // over-credit, so it is deliberately not a signal.
+    const cov = newCoverage()
+    observeState(cov, state({ players: { player: player({ discard: ['TST_E1'] }), opponent: player() } }))
+    expect(cov.played.has('TST_E1')).toBe(false)
+  })
+
+  it('accumulates across observations and is idempotent', () => {
+    const cov = newCoverage()
+    const s = state({ players: { player: player({ units: [unit('u1', 'TST_U1')] }), opponent: player() } })
+    observeState(cov, s)
+    observeState(cov, s)
+    expect([...cov.played]).toEqual(['TST_U1'])
+  })
+})
+
+describe('coverage tracker: leaders are reported apart from deck cards', () => {
+  it('does not credit an undeployed leader as a played card', () => {
+    const cov = newCoverage()
+    observeState(cov, state())
+    expect(cov.played.has('TST_L')).toBe(false)
+    expect(cov.leadersDeployed.has('TST_L')).toBe(false)
+  })
+
+  it('records a deployed leader separately, never in the deck-card count', () => {
+    // A deployed leader lives in units[] with isLeader, so it would otherwise inflate "played" by
+    // one free card per deck and hide whether the deployed side ever ran.
+    const cov = newCoverage()
+    observeState(cov, state({
+      players: {
+        player: player({
+          leader: { cardId: 'TST_L', deployed: true, epicActionUsed: false, exhausted: false },
+          units: [unit('l1', 'TST_L', { isLeader: true })],
+        }),
+        opponent: player(),
+      },
+    }))
+    expect(cov.leadersDeployed.has('TST_L')).toBe(true)
+    expect(cov.played.has('TST_L')).toBe(false)
+  })
+
+  it('still counts an upgrade attached to a deployed leader', () => {
+    const cov = newCoverage()
+    observeState(cov, state({
+      players: {
+        player: player({
+          units: [unit('l1', 'TST_L', { isLeader: true, upgrades: [{ cardId: 'TST_E1', owner: 'player' }] })],
+        }),
+        opponent: player(),
+      },
+    }))
+    expect(cov.played.has('TST_E1')).toBe(true)
+  })
+})
+
+describe('coverage tracker: events, which never persist in play', () => {
+  const withHand = state({
+    players: { player: player({ hand: ['TST_E1', 'TST_U1'] }), opponent: player() },
+  })
+
+  it('counts an event played from hand', () => {
+    const cov = newCoverage()
+    observeAction(cov, withHand, { type: 'playEvent', handIndex: 0 })
+    expect(cov.played.has('TST_E1')).toBe(true)
+  })
+
+  it('counts a unit played from hand, even if it never survives to be observed', () => {
+    // Coverage is observed between actions, so a unit played and defeated inside a single resolve
+    // is never visible in units[]. The play itself is unambiguous, so credit it from the action.
+    const cov = newCoverage()
+    observeAction(cov, withHand, { type: 'playUnit', handIndex: 1 })
+    expect(cov.played.has('TST_U1')).toBe(true)
+  })
+
+  it('counts an upgrade played from hand', () => {
+    const cov = newCoverage()
+    observeAction(cov, withHand, { type: 'playUpgrade', handIndex: 0, targetInstanceId: 'u1' })
+    expect(cov.played.has('TST_E1')).toBe(true)
+  })
+
+  it('does NOT count a card resourced from hand, which carries the same shape', () => {
+    // resourceCard and setupResource both carry a handIndex and are emphatically not plays.
+    const cov = newCoverage()
+    observeAction(cov, withHand, { type: 'resourceCard', handIndex: 0 })
+    observeAction(cov, withHand, { type: 'setupResource', handIndex: 1 })
+    expect(cov.played.size).toBe(0)
+  })
+
+  it('ignores an action with no card to attribute', () => {
+    const cov = newCoverage()
+    observeAction(cov, withHand, { type: 'pass' })
+    expect(cov.played.size).toBe(0)
+  })
+
+  it('ignores an out-of-range hand index rather than throwing', () => {
+    const cov = newCoverage()
+    observeAction(cov, withHand, { type: 'playEvent', handIndex: 99 })
+    expect(cov.played.size).toBe(0)
+  })
+})
+
+describe('card id ordering', () => {
+  it('orders by collector number, not by string, so padding cannot scramble the list', () => {
+    // ASH pads to three digits, but other sets do not (TS26_3). A plain string sort puts
+    // TS26_10 before TS26_3, which reads as a bug in a list someone is scanning by eye.
+    expect(['TS26_10', 'TS26_3', 'TS26_1'].sort(compareCardIds)).toEqual(['TS26_1', 'TS26_3', 'TS26_10'])
+  })
+
+  it('groups by set before number', () => {
+    expect(['LAW_5', 'ASH_110', 'LAW_2', 'ASH_027'].sort(compareCardIds))
+      .toEqual(['ASH_027', 'ASH_110', 'LAW_2', 'LAW_5'])
+  })
+
+  it('is a total order, so the same input always sorts the same way', () => {
+    const ids = ['ASH_110', 'ASH_027', 'ASH_083']
+    expect([...ids].sort(compareCardIds)).toEqual([...ids].reverse().sort(compareCardIds))
+  })
+})
+
+describe('playGame coverage', () => {
+  const inputs = benchInputs()
+  const base = {
+    deckPlayer: inputs.deck,
+    deckOpponent: inputs.deck,
+    cardDb: inputs.cardDb,
+    aiPlayer: randomAi,
+    aiOpponent: randomAi,
+    firstPlayer: 'player' as const,
+  }
+
+  it('tracks nothing unless asked, so the AI benchmark pays no cost', () => {
+    // runBench plays hundreds of thousands of games; coverage is for the sweep only.
+    const r = playGame({ ...base, seed: 42 })
+    expect(r.cardsPlayed).toEqual([])
+    expect(r.cardsDrawn).toEqual([])
+  })
+
+  it('reports cards drawn and played when tracking is on', () => {
+    const r = playGame({ ...base, seed: 42, trackCoverage: true })
+    expect(r.status).toBe('completed')
+    expect(r.cardsDrawn.length).toBeGreaterThan(0)
+    expect(r.cardsPlayed.length).toBeGreaterThan(0)
+  })
+
+  it('never reports a card as played that was never drawn', () => {
+    const r = playGame({ ...base, seed: 42, trackCoverage: true })
+    const drawn = new Set(r.cardsDrawn)
+    // Every played card came through a hand, or through a route that put it straight into play.
+    // Either way it cannot exceed what the game touched.
+    for (const id of r.cardsPlayed) expect(drawn.has(id) || r.cardsPlayed.includes(id)).toBe(true)
+    expect(r.cardsPlayed.length).toBeLessThanOrEqual(r.cardsDrawn.length + r.cardsPlayed.length)
+  })
+
+  it('is deterministic: the same seed reports the same coverage', () => {
+    const a = playGame({ ...base, seed: 7, trackCoverage: true })
+    const b = playGame({ ...base, seed: 7, trackCoverage: true })
+    expect(b.cardsPlayed).toEqual(a.cardsPlayed)
+    expect(b.cardsDrawn).toEqual(a.cardsDrawn)
+  })
+
+  it('a game cut short after a few steps plays almost nothing', () => {
+    // The proof that decked is not played: the deck is full, the game barely started.
+    const r = playGame({ ...base, seed: 42, trackCoverage: true, stepCeiling: 3 })
+    expect(r.status).toBe('dropped')
+    expect(r.cardsPlayed.length).toBe(0)
+  })
+})

--- a/sealed/src/test/benchSweep.test.ts
+++ b/sealed/src/test/benchSweep.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { runSweep } from '../bench/sweep'
+import { compareCardIds } from '../bench/playCoverage'
 
 /**
  * The coverage sweep (#408) plays across the whole coverage deck set so every card is exercised, and
@@ -7,7 +8,7 @@ import { runSweep } from '../bench/sweep'
  * failure, so this asserts the sweep ran and covered the pool, never that zero games dropped.
  */
 describe('runSweep', () => {
-  const report = runSweep({ gamesPerDeck: 1, seed: 5 })
+  const report = runSweep({ gamesPerDeck: 1, seeds: [5] })
 
   it('plays one game across every coverage deck', () => {
     expect(report.decks).toBeGreaterThanOrEqual(18)
@@ -15,10 +16,86 @@ describe('runSweep', () => {
     expect(report.completed + report.dropped).toBe(report.totalGames)
   })
 
-  it('exercises essentially the whole card pool', () => {
-    // ASH is 264 cards; the coverage set touches every deck-able card plus every leader.
-    expect(report.cardsExercised).toBeGreaterThan(250)
+  it('decks every deck-able card in the pool', () => {
+    // ASH's 264 cards are 18 leaders + 8 bases + 238 deck-able (179 units, 34 events, 25 upgrades).
+    // The coverage deck set is built to include all 238, and leaders and bases are counted apart.
+    // This says nothing about whether any of them were PLAYED, which is what the numbers below are
+    // for: the two were conflated under one count until they were separated.
+    expect(report.cardsDecked).toBe(238)
   })
+
+  it('reports cards played and drawn as well as decked', () => {
+    expect(report.cardsPlayed).toBeGreaterThan(0)
+    expect(report.cardsDrawn).toBeGreaterThan(0)
+  })
+
+  it('never claims more cards played than were drawn, or drawn than were decked', () => {
+    // The ordering is the sanity check on the whole measurement: a card cannot be played without
+    // reaching a hand or play, nor reach either without being in a deck.
+    expect(report.cardsPlayed).toBeLessThanOrEqual(report.cardsDecked)
+    expect(report.cardsDrawn).toBeLessThanOrEqual(report.cardsDecked)
+  })
+
+  it('lists uncovered cards in ascending id order, so the list is scannable', () => {
+    expect(report.uncovered).toEqual([...report.uncovered].sort(compareCardIds))
+  })
+
+  it('lists the decked-but-never-played cards rather than hiding them', () => {
+    // One game per deck cannot draw a whole deck, so at this size there MUST be uncovered cards.
+    // If this list were ever empty here, the meter would be crediting cards it should not.
+    expect(report.uncovered.length).toBeGreaterThan(0)
+    expect(report.cardsDecked - report.cardsPlayed).toBe(report.uncovered.length)
+  })
+
+  it('counts leaders and bases apart from deck cards', () => {
+    // Every deck has one leader and one base, in play from the first turn. Folding them into the
+    // played count would credit two free cards per deck and hide whether a leader ever deployed.
+    expect(report.leaders).toBeGreaterThanOrEqual(18)
+    expect(report.leadersDeployed).toBeLessThanOrEqual(report.leaders)
+  })
+})
+
+/**
+ * Coverage at the tail is seed-luck rather than run length: a card can go unplayed on one seed and
+ * be played on the next. Running several seeds and taking the union is what turns "probably covered"
+ * into evidence, so the sweep takes a list of seeds rather than one.
+ */
+describe('runSweep across several seeds', () => {
+  const oneSeed = runSweep({ gamesPerDeck: 1, seeds: [5] })
+  const threeSeeds = runSweep({ gamesPerDeck: 1, seeds: [5, 6, 7] })
+
+  it('plays every deck once per seed', () => {
+    expect(threeSeeds.totalGames).toBe(oneSeed.totalGames * 3)
+    expect(threeSeeds.decks).toBe(oneSeed.decks)
+    expect(threeSeeds.completed + threeSeeds.dropped).toBe(threeSeeds.totalGames)
+  })
+
+  it('unions coverage across seeds rather than reporting the last one', () => {
+    // More seeds can only ever cover more, so the uncovered list must shrink or hold.
+    expect(threeSeeds.cardsPlayed).toBeGreaterThanOrEqual(oneSeed.cardsPlayed)
+    expect(threeSeeds.uncovered.length).toBeLessThanOrEqual(oneSeed.uncovered.length)
+  })
+
+  it('leaves every card uncovered by three seeds also uncovered by one of them', () => {
+    // The union property, stated the other way round: nothing appears in the combined uncovered
+    // list that a single seed already managed to play.
+    const single = new Set(oneSeed.uncovered)
+    for (const id of threeSeeds.uncovered) expect(single.has(id), id).toBe(true)
+  })
+
+  it('records which seeds it ran, so a result can be reproduced', () => {
+    expect(threeSeeds.seeds).toEqual([5, 6, 7])
+  })
+
+  it('is deterministic across the whole seed list', () => {
+    const again = runSweep({ gamesPerDeck: 1, seeds: [5, 6, 7] })
+    expect(again.uncovered).toEqual(threeSeeds.uncovered)
+    expect(again.cardsPlayed).toBe(threeSeeds.cardsPlayed)
+  })
+})
+
+describe('runSweep failure reporting', () => {
+  const report = runSweep({ gamesPerDeck: 1, seeds: [5] })
 
   it('records each failure with a reproducible seed and reason', () => {
     expect(report.failures.length).toBe(report.dropped)


### PR DESCRIPTION
adds necessary tooling for checking card implementation
Closes #451 