### PR TITLE
bug/sabine-exhaust

### DIFF
--- a/sealed/docs/abilities.md
+++ b/sealed/docs/abilities.md
@@ -66,6 +66,17 @@ unit fire on other units' attacks:
 `onAttackEnd` still fires if the attacker was defeated in the combat (CR 7.6), falling back to its
 last-known state with its upgrades.
 
+Two triggers fire **once per event, not once per item**, matching cards worded "1 or more":
+
+- **`whenUpgradeAttached`** fires once however many upgrades attach together. Giving a unit three
+  Advantage tokens is one event, so Sabine Wren offers one exhaust, not three. The boundary is one
+  call to `giveTokens`, which attaches the whole batch and then fires: an upgrade attaching and that
+  upgrade's own effect then granting tokens are two separate events and do fire twice.
+- **`whenDrawCards`** fires once per draw, however many cards it drew.
+
+Granting tokens one at a time in a loop therefore fires these triggers repeatedly and is a bug; use
+`giveTokens` with a count.
+
 ## Static hooks
 
 Card-type-agnostic, all on `CardDefinition`:

--- a/sealed/src/engine/cardDefinitions.ts
+++ b/sealed/src/engine/cardDefinitions.ts
@@ -1,6 +1,6 @@
 import type { EffectContext } from './abilities'
 import { registerCard } from './abilities'
-import { giveToken, exhaustUnit, drawCards, returnOtherUpgradesToHand, returnUpgradeFromDiscardToHand, defeatUpgrade, defeatUpgradeAt, createTokenUnit, createTokenUnits, findUnit, searchCount, grantNextUnit, healUnit, healBase, dealDamageToBase, exhaustReadyResource, readyResource, readyUnit } from './effects'
+import { giveToken, giveTokens, exhaustUnit, drawCards, returnOtherUpgradesToHand, returnUpgradeFromDiscardToHand, defeatUpgrade, defeatUpgradeAt, createTokenUnit, createTokenUnits, findUnit, searchCount, grantNextUnit, healUnit, healBase, dealDamageToBase, exhaustReadyResource, readyResource, readyUnit } from './effects'
 import { dealDamageToUnit, defeatUnit } from './combat'
 import { effectiveHp, effectivePower } from './stats'
 import { TOKEN_SHIELD, TOKEN_ADVANTAGE, hasToken } from './tokenUpgrades'
@@ -91,7 +91,7 @@ registerCard('ASH_182', { // Unfettered Ambition — Advantage per non-Advantage
       if (!found) return s
       const n = found.unit.upgrades.filter(u => s.cards[u.cardId]?.name !== 'Advantage').length
       let next = s
-      for (let i = 0; i < n; i++) next = giveToken(next, ctx.sourceInstanceId!, TOKEN_ADVANTAGE)
+      next = giveTokens(next, ctx.sourceInstanceId!, TOKEN_ADVANTAGE, n)
       return next
     },
   }],
@@ -225,7 +225,7 @@ registerCard('ASH_015', { // Emperor Palpatine — front (undeployed) + deployed
       effect: (s, ctx) => {
         const others = s.players[ctx.owner].units.filter(u => u.instanceId !== ctx.targetInstanceId).length
         let next = s
-        for (let i = 0; i < others; i++) next = giveToken(next, ctx.targetInstanceId!, TOKEN_ADVANTAGE)
+        next = giveTokens(next, ctx.targetInstanceId!, TOKEN_ADVANTAGE, others)
         return next
       },
     }],
@@ -807,12 +807,6 @@ registerCard('ASH_040', { // Poe Dameron — all units lose Sentinel
 })
 
 // ── Units — "When Played" effects ──────────────────────────────
-/** Give `n` copies of a token to a unit. */
-const giveTokens = (s: GameState, id: string, token: string, n: number): GameState => {
-  let next = s
-  for (let i = 0; i < n; i++) next = giveToken(next, id, token)
-  return next
-}
 const whenPlayed = (description: string, effect: (s: GameState, ctx: { owner: PlayerId; cardId: string; sourceInstanceId?: string }) => GameState) => ({
   abilities: [{ trigger: 'whenPlayed' as const, description, effect }],
 })

--- a/sealed/src/engine/effects.ts
+++ b/sealed/src/engine/effects.ts
@@ -42,19 +42,38 @@ function patchUnit(state: GameState, owner: PlayerId, instanceId: string, patch:
   }
 }
 
-/** Attach a token upgrade (Shield/Experience/Advantage) to a unit, owned by its controller. */
-export function giveToken(state: GameState, instanceId: string, tokenId: string): GameState {
+/**
+ * Attach `count` token upgrades (Shield/Experience/Advantage) to a unit, owned by its controller.
+ *
+ * **All of them attach, then the trigger fires once** (#498). Sabine Wren reads "When 1 or more
+ * upgrades attach to this unit", so a three-token grant is one event, not three. Granting them
+ * one-at-a-time raised three separate choices on prod and let the opponent exhaust two units off a
+ * single Zeb play.
+ *
+ * The boundary is one **call**, which is one trigger's worth of attaching. Two separate effects each
+ * granting in the same action are two events and fire twice, which is the reading two judges
+ * confirmed: Unfettered Ambition attaching, then its own effect granting Advantage, is two.
+ *
+ * A count of zero is not an attach event, so it neither attaches nor fires.
+ */
+export function giveTokens(state: GameState, instanceId: string, tokenId: string, count: number): GameState {
   const found = findUnit(state, instanceId)
-  if (!found) return state
-  const next = patchUnit(state, found.owner, instanceId, u => ({ ...u, upgrades: [...u.upgrades, { cardId: tokenId, owner: found.owner }] }))
+  if (!found || count <= 0) return state
+  const tokens = Array.from({ length: count }, () => ({ cardId: tokenId, owner: found.owner }))
+  const next = patchUnit(state, found.owner, instanceId, u => ({ ...u, upgrades: [...u.upgrades, ...tokens] }))
   return fireUpgradeAttached(next, instanceId)
+}
+
+/** Attach a single token upgrade. See {@link giveTokens} for why the count-many form exists. */
+export function giveToken(state: GameState, instanceId: string, tokenId: string): GameState {
+  return giveTokens(state, instanceId, tokenId, 1)
 }
 
 /**
  * Fire "when 1 or more upgrades attach to this unit" (Sabine Wren) on the receiving unit.
  * Called from every attach site: token grants (here), `playUpgrade`, and a Shielded entry.
- * Note: granting N tokens one-at-a-time fires it N times — fine for the current card, which is a
- * "may", but a future "exactly once per attach event" card would need batching.
+ * Batching is {@link giveTokens}' job: this fires once per call, so callers granting several tokens
+ * must attach them together rather than in a loop.
  */
 export function fireUpgradeAttached(state: GameState, instanceId: string, upgradePlayed = false): GameState {
   const found = findUnit(state, instanceId)

--- a/sealed/src/engine/resolve.ts
+++ b/sealed/src/engine/resolve.ts
@@ -7,7 +7,7 @@ import { addResourceFromHand, payCost, readyAllResources } from './resources'
 import { effectiveCost, enemyAttackTargets, affordableHandUnits, validUpgradeTargets } from './legalMoves'
 import { runTrigger, runUnitTrigger, runLeaderTrigger, getCardDefinition, actionAbilityKey, leaderActions, stampChoiceSource, type TriggerPoint, type EffectContext } from './abilities'
 import { applyUnitDamage, dealDamageToUnit, defeatUnit, sweepStateBasedDefeats, preventionOffer } from './combat'
-import { exhaustUnit, findUnit, giveToken, fireUpgradeAttached, dealDamageToBase, baseDamageAfterPrevention, defeatUpgradeAt, healUnit, healBase, resourceTopOfDeck, drawCards, discardFromHand, createTokenUnit, createTokenUnits, returnUpgradeFromDiscardToHand, returnUnitToHand, grantNextUnit, readyUnit, searchCount, bottomTopCards, returnUpgradeToHand, defeatTokensOn } from './effects'
+import { exhaustUnit, findUnit, giveToken, giveTokens, fireUpgradeAttached, dealDamageToBase, baseDamageAfterPrevention, defeatUpgradeAt, healUnit, healBase, resourceTopOfDeck, drawCards, discardFromHand, createTokenUnit, createTokenUnits, returnUpgradeFromDiscardToHand, returnUnitToHand, grantNextUnit, readyUnit, searchCount, bottomTopCards, returnUpgradeToHand, defeatTokensOn } from './effects'
 import { seededShuffle, nextSeed } from './rng'
 import { effectivePower, effectiveHp, friendlyAdvantageInert } from './stats'
 import { hasKeyword, unitHasKeyword, unitKeywordValue, unitNegatesOverwhelm, unitDealsDamageFirst, unitSpillsExcessToUnit, unitHasTrait } from './keywords'
@@ -550,7 +550,7 @@ function mayDamageFollowUps(state: GameState, choice: PendingChoice & { kind: 'm
   if (choice.rewardIfDefeated && !findUnit(next, targetInstanceId)) {
     const reward = choice.rewardIfDefeated
     if ('instanceId' in reward) {
-      for (let i = 0; i < reward.count; i++) next = giveToken(next, reward.instanceId, TOKEN_ADVANTAGE)
+      next = giveTokens(next, reward.instanceId, TOKEN_ADVANTAGE, reward.count)
     } else {
       // Justifier: give Advantage to a chosen unit.
       const targets = [...next.players.player.units, ...next.players.opponent.units].map(u => u.instanceId)
@@ -846,7 +846,7 @@ function resolveAccept(state: GameState, choiceId: string, targetInstanceId?: st
       // Emperor Palpatine: give the chosen unit an Advantage token per other friendly unit.
       if (targetInstanceId) {
         const others = next.players[choice.controller].units.filter(u => u.instanceId !== targetInstanceId).length
-        for (let i = 0; i < others; i++) next = giveToken(next, targetInstanceId, TOKEN_ADVANTAGE)
+        next = giveTokens(next, targetInstanceId, TOKEN_ADVANTAGE, others)
       }
       break
     case 'mayExhaustLeaderForAdvantage': {
@@ -883,7 +883,7 @@ function resolveAccept(state: GameState, choiceId: string, targetInstanceId?: st
       break
     case 'mayGiveTokens':
       // Give `count` of a token to the chosen unit — Attendant Navigator, Anakin, Trexler.
-      if (targetInstanceId) for (let i = 0; i < choice.count; i++) next = giveToken(next, targetInstanceId, choice.token)
+      if (targetInstanceId) next = giveTokens(next, targetInstanceId, choice.token, choice.count)
       break
     case 'mayExhaustLeaderGiveAdvantage': {
       // Ezra front: exhaust the (undeployed) leader to give the chosen unit an Advantage token.
@@ -1301,7 +1301,7 @@ function resolveAccept(state: GameState, choiceId: string, targetInstanceId?: st
         const healed = found ? Math.min(choice.maxHeal, found.unit.damage) : 0
         if (healed > 0) {
           next = healUnit(next, targetInstanceId, healed)
-          for (let i = 0; i < healed; i++) next = giveToken(next, targetInstanceId, TOKEN_ADVANTAGE)
+          next = giveTokens(next, targetInstanceId, TOKEN_ADVANTAGE, healed)
         }
       }
       break
@@ -1366,7 +1366,7 @@ function resolveAccept(state: GameState, choiceId: string, targetInstanceId?: st
     case 'opponentGivesAdvantage':
       // Sabine front: the opponent gives `count` Advantage tokens to their chosen unit.
       if (targetInstanceId && choice.targets.includes(targetInstanceId)) {
-        for (let i = 0; i < choice.count; i++) next = giveToken(next, targetInstanceId, TOKEN_ADVANTAGE)
+        next = giveTokens(next, targetInstanceId, TOKEN_ADVANTAGE, choice.count)
       }
       break
     case 'multiPick':

--- a/sealed/src/test/reactiveTriggers.test.ts
+++ b/sealed/src/test/reactiveTriggers.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest'
 import { resolve } from '../engine/resolve'
 import { dealDamageToUnit } from '../engine/combat'
 import '../engine/cardDefinitions' // side effect: registers card behaviours
-import { drawCards, dealDamageToBase, defeatUpgradeAt } from '../engine/effects'
-import { TOKEN_ADVANTAGE } from '../engine/tokenUpgrades'
+import { drawCards, dealDamageToBase, defeatUpgradeAt, giveTokens } from '../engine/effects'
+import { TOKEN_ADVANTAGE, TOKEN_SHIELD } from '../engine/tokenUpgrades'
 import { state, player, unit, card, ready, CARDS } from './helpers/engineFixtures'
 import type { GameState } from '../engine/types'
 
@@ -138,6 +138,78 @@ describe('whenUpgradeAttached — Sabine Wren (208)', () => {
     })
     const played = resolve(board, { type: 'playUpgrade', handIndex: 0, targetInstanceId: 'g' })
     expect(played.pendingChoices ?? []).toHaveLength(0)
+  })
+
+  /**
+   * **"When 1 or more upgrades attach" is one trigger per attach event, whatever the count** (#498).
+   *
+   * Printed text: "When 1 or more upgrades attach to this unit (including from Shielded): You may
+   * exhaust a ground unit." Reported from prod: Zeb put 3 Advantage on Sabine in one go and she
+   * raised three choices (`u18`, `u18#1`, `u18#2`), letting the opponent exhaust two units off a
+   * single play. Two judges confirm the reading is per trigger, not per token.
+   *
+   * `giveTokens` is the batching seam: attach all N, then fire once.
+   */
+  it('fires once for a batch of tokens, however many attach', () => {
+    const board = state({
+      cards: S,
+      players: {
+        player: player({ units: [unit('sw', 'ASH_208', { arena: 'ground' })] }),
+        opponent: player(),
+      },
+    })
+    const granted = giveTokens(board, 'sw', TOKEN_ADVANTAGE, 3)
+    expect(U(granted, 'sw').upgrades.filter(u => u.cardId === TOKEN_ADVANTAGE), 'all three still attach').toHaveLength(3)
+    expect(granted.pendingChoices ?? [], 'but only one trigger').toHaveLength(1)
+  })
+
+  /** Two separate grants are two events, so they fire twice. Per trigger, not per action. */
+  it('fires again for a second, separate grant', () => {
+    const board = state({
+      cards: S,
+      players: {
+        player: player({ units: [unit('sw', 'ASH_208', { arena: 'ground' })] }),
+        opponent: player(),
+      },
+    })
+    const twice = giveTokens(giveTokens(board, 'sw', TOKEN_ADVANTAGE, 2), 'sw', TOKEN_ADVANTAGE, 2)
+    expect(twice.pendingChoices ?? []).toHaveLength(2)
+  })
+
+  /** Granting nothing is not an attach event, so it must neither attach nor fire. */
+  it('does nothing at all for a count of zero', () => {
+    const board = state({
+      cards: S,
+      players: {
+        player: player({ units: [unit('sw', 'ASH_208', { arena: 'ground' })] }),
+        opponent: player(),
+      },
+    })
+    const none = giveTokens(board, 'sw', TOKEN_ADVANTAGE, 0)
+    expect(U(none, 'sw').upgrades).toHaveLength(0)
+    expect(none.pendingChoices ?? []).toHaveLength(0)
+  })
+
+  /**
+   * **The real two-event case.** Unfettered Ambition attaching is one event; the Advantage its own
+   * effect then grants is a second. So Sabine fires exactly **twice**, not once per token: the card
+   * counts non-Advantage upgrades, so with a Shield and this upgrade on her it grants two at once.
+   */
+  it('fires twice for an upgrade whose own effect then grants tokens', () => {
+    const cards = { ...S, ASH_182: card({ id: 'ASH_182', type: 'upgrade', cost: 1, power: 0, hp: 0 }) }
+    const board = state({
+      cards,
+      players: {
+        player: player({
+          hand: ['ASH_182'],
+          resources: ready(10),
+          units: [unit('sw', 'ASH_208', { arena: 'ground', upgrades: [{ cardId: TOKEN_SHIELD, owner: 'player' }] })],
+        }),
+        opponent: player(),
+      },
+    })
+    const played = resolve(board, { type: 'playUpgrade', handIndex: 0, targetInstanceId: 'sw' })
+    expect(played.pendingChoices ?? [], 'the attach, then the grant it causes').toHaveLength(2)
   })
 })
 


### PR DESCRIPTION
fires the upgrade-attached trigger once per event not per token

Close #498 