### PR TITLE
bug/sealed-game-over-preempts discards pending choices on a win

### DIFF
--- a/sealed/docs/choices.md
+++ b/sealed/docs/choices.md
@@ -40,6 +40,25 @@ making the answered ability appear not to resolve. There is deliberately no such
 first, then control passes; round-start choices (`resumeAtInitiative`) begin the action phase with
 the initiative holder, mid-turn choices `advanceTurn`.
 
+### A decided game has no pending choices
+
+**CR 6.6.2**: once a player's base has 0 remaining HP they "cannot take any actions, and cannot resolve
+any abilities or effects", and CR 1.16.5 ranks base defeat first among the state-based situations that
+pre-empt waiting triggers. So winning discards whatever was waiting, in two places:
+
+- `checkWin` clears `pendingChoices` when it sets a winner.
+- `pushChoice` refuses to add one to a decided game.
+
+Both, because whether a trigger is raised before or after the win check varies by card and by code path.
+A choice left pending on a won game is **unanswerable**, since `legalMoves` returns nothing once
+`winner` is set, so it strands whatever is presenting it: an attack that won the game while triggering
+Camtono put a card-reveal on top of the game-over screen that could be neither played nor dismissed, and
+the menu could not be reached.
+
+The rule belongs in the engine rather than in overlay ordering. A choice that does not exist cannot be
+rendered, whereas a UI fix would leave the impossible state in the model for the next surface to trip
+over.
+
 ### Suspending combat
 
 An attack that raises a choice mid-flight splits into `beginAttack` (exhaust, Restore, `onDefense`,

--- a/sealed/src/engine/resolve.ts
+++ b/sealed/src/engine/resolve.ts
@@ -2130,9 +2130,15 @@ function checkWin(state: GameState): GameState {
   }
   const playerLost = defeated('player')
   const opponentLost = defeated('opponent')
-  if (playerLost && opponentLost) return { ...state, winner: 'draw' }
-  if (playerLost) return { ...state, winner: 'opponent' }
-  if (opponentLost) return { ...state, winner: 'player' }
+  // Anything still waiting is discarded with the win. CR 6.6.2: a player on 0 remaining HP "cannot take
+  // any actions, and cannot resolve any abilities or effects", and CR 1.16.5 ranks base defeat first
+  // among the state-based situations that pre-empt waiting triggers. Leaving a choice pending would
+  // strand it: `legalMoves` returns nothing for a decided game, so it could never be answered.
+  const decided = (winner: GameState['winner']): GameState =>
+    ({ ...state, winner, pendingChoices: undefined })
+  if (playerLost && opponentLost) return decided('draw')
+  if (playerLost) return decided('opponent')
+  if (opponentLost) return decided('player')
   return state
 }
 

--- a/sealed/src/engine/types.ts
+++ b/sealed/src/engine/types.ts
@@ -691,6 +691,12 @@ export function removeChoice(state: GameState, id: string): GameState {
 
 /** Append a choice to the pending queue (order = trigger order; the controller reorders). */
 export function pushChoice(state: GameState, choice: PendingChoice): GameState {
+  // A decided game resolves nothing (CR 6.6.2: once a player's base has 0 remaining HP they "cannot
+  // resolve any abilities or effects"). Guarded HERE rather than at each caller because whether a
+  // trigger is raised before or after the win check varies by card and by code path: Camtono revealed a
+  // card on top of the game-over screen after an attack that won the game, and the player could neither
+  // answer it nor dismiss it, since a decided game offers no legal moves.
+  if (state.winner !== null) return state
   // Guarantee a unique id among pending choices — different triggers on the same played
   // unit (e.g. Support + Greef Karga) would otherwise collide and mislabel each other.
   const existing = state.pendingChoices ?? []

--- a/sealed/src/test/gameOverPreempts.test.ts
+++ b/sealed/src/test/gameOverPreempts.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { resolve } from '../engine/resolve'
+import { legalMoves } from '../engine/legalMoves'
+import { hasPendingChoices, pushChoice } from '../engine/types'
+import { state, player, unit, card, ready, CARDS } from './helpers/engineFixtures'
+import type { GameState } from '../engine/types'
+import '../engine/cardDefinitions'
+
+/**
+ * A decided game resolves nothing (#523).
+ *
+ * **CR 6.6.2**: "Once a player's base has 0 remaining HP, they cannot take any actions, and cannot
+ * resolve any abilities or effects." CR 1.16.5 ranks base defeat first among the state-based situations
+ * that take priority over waiting triggered abilities.
+ *
+ * Reported from live play: an attack that finished the game also triggered Camtono, so the game-over
+ * screen and a "look at the top card of your deck" overlay appeared together. The card could not be
+ * played, because the game was over and the engine offered no moves, and it could not be dismissed,
+ * so the player could not reach the menu either. An unrecoverable screen.
+ *
+ * Fixing that as a z-order question would have been treating the symptom. The choice should never have
+ * existed: a won game has nothing pending, and the UI cannot render an overlay for a choice that is not
+ * there.
+ */
+
+const cards = {
+  ...CARDS,
+  KILLER: card({ id: 'KILLER', type: 'unit', arena: 'ground', cost: 3, power: 30, hp: 3 }),
+}
+
+/** Our attacker can finish their base outright this action. */
+const aboutToWin = (): GameState => state({
+  cards,
+  phase: 'action',
+  activePlayer: 'player',
+  players: {
+    player: player({ resources: ready(3), units: [unit('a', 'KILLER')] }),
+    opponent: player({ base: { cardId: 'TST_B', damage: 0 } }),
+  },
+})
+
+describe('a decided game', () => {
+  it('is actually decided by the fixture, or the rest proves nothing', () => {
+    const won = resolve(aboutToWin(), { type: 'attack', attackerId: 'a', target: { kind: 'base' } })
+    expect(won.winner).toBe('player')
+  })
+
+  /**
+   * The engine already refuses to offer moves once the game is decided, which is why the reported
+   * screen was unrecoverable rather than merely wrong: the overlay asked for an answer that no legal
+   * move could give.
+   */
+  it('offers no legal moves', () => {
+    const won = resolve(aboutToWin(), { type: 'attack', attackerId: 'a', target: { kind: 'base' } })
+    expect(legalMoves(won)).toEqual([])
+  })
+
+  /**
+   * The fix. A choice outstanding when the base falls is discarded rather than left waiting, so nothing
+   * downstream has to special-case a pending choice that can never be answered.
+   */
+  it('drops any choice that was already pending', () => {
+    const pending = pushChoice(aboutToWin(), {
+      kind: 'mayPlayTopFree', id: 'camtono', controller: 'player', unitId: 'a', cardId: 'TST_U1',
+    })
+    expect(hasPendingChoices(pending), 'the fixture must start with a choice owed').toBe(true)
+
+    const won = resolve(pending, { type: 'attack', attackerId: 'a', target: { kind: 'base' } })
+    expect(won.winner).toBe('player')
+    expect(hasPendingChoices(won), 'a decided game resolves nothing (CR 6.6.2)').toBe(false)
+  })
+
+  /**
+   * And the other direction: a trigger raised BY the winning action cannot install itself afterwards.
+   * Clearing on the way through is not enough on its own, because whether a choice is pushed before or
+   * after the win check varies by card and by code path.
+   */
+  it('refuses a choice pushed into an already decided game', () => {
+    const won = resolve(aboutToWin(), { type: 'attack', attackerId: 'a', target: { kind: 'base' } })
+    const after = pushChoice(won, {
+      kind: 'mayPlayTopFree', id: 'camtono', controller: 'player', unitId: 'a', cardId: 'TST_U1',
+    })
+    expect(hasPendingChoices(after)).toBe(false)
+  })
+
+  /** The guard must not touch a live game, or every trigger in the set stops working. */
+  it('leaves a live game alone', () => {
+    const live = pushChoice(aboutToWin(), {
+      kind: 'mayPlayTopFree', id: 'camtono', controller: 'player', unitId: 'a', cardId: 'TST_U1',
+    })
+    expect(hasPendingChoices(live)).toBe(true)
+    expect(legalMoves(live).length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
Closes #523 