### PR TITLE
bug/populate-base-job fixes the nightly pipeline

### DIFF
--- a/docs/architecture-implementation.md
+++ b/docs/architecture-implementation.md
@@ -164,7 +164,7 @@ scripts/
   validate-bases.mjs              Playwright script — opens a headed Chromium window and iterates every base for semi-automated visual QA (see architecture-process.md)
   validate-errors.mjs             Playwright script — opens a headed Chromium window and steps through all five error/info message states for semi-automated visual QA (see architecture-process.md)
   measure-performance.mjs         Playwright script — measures setup ready time, LCP, preview image time, and game image time across three resolution tiers (low/normal/hi res) per iteration; reports min/median/max (see project-overview.md)
-  populate-base-aspects.mjs       Fetches base card data from swuapi.com and the swu-db proxy, merges them into baseKey→aspect pairs, and writes to the base_aspects InfluxDB measurement; exports buildBaseAspects and toLineProtocol for unit testing; run by the GitHub Actions daily workflow and on-demand via node scripts/populate-base-aspects.mjs
+  populate-base-aspects.mjs       Fetches base card data from swuapi.com and the swu-db proxy (one query per set, skipping sets swu-db cannot serve), merges them into baseKey→aspect pairs, and writes to the base_aspects InfluxDB measurement; exports buildBaseAspects, toLineProtocol, fetchSetCodes and fetchSwuDbBases for unit testing; run by the GitHub Actions daily workflow and on-demand via node scripts/populate-base-aspects.mjs
   check-influxdb-usage.mjs        Queries the dmgctrl InfluxDB bucket row count and prints an estimated storage size against the 5GB free-tier limit; reads credentials from .env.influxdb automatically; run with node scripts/check-influxdb-usage.mjs
 ```
 

--- a/docs/architecture-process.md
+++ b/docs/architecture-process.md
@@ -361,7 +361,9 @@ Feature use is measured via usage events (sessions containing at least one relev
 
 ### `base_aspects` InfluxDB measurement
 
-A separate InfluxDB measurement (`base_aspects`) stores a static `baseKey → aspect` lookup used by the base popularity panel to colour bars. It is populated by `scripts/populate-base-aspects.mjs`, which fetches base card data from swuapi.com (active sets) and the swu-db proxy (rotated sets) and writes one record per base using a fixed timestamp so re-runs overwrite rather than append.
+A separate InfluxDB measurement (`base_aspects`) stores a static `baseKey → aspect` lookup used by the base popularity panel to colour bars. It is populated by `scripts/populate-base-aspects.mjs`, which fetches base card data from swuapi.com (active sets) and the swu-db proxy (rotated sets) and writes one record per base. Every record in a run shares a single timestamp, so the Grafana query can select one whole run by its time.
+
+swuapi is the primary source: the script reads its set list, then queries swu-db only for the sets swuapi has no bases for. Those swu-db queries are **scoped to one set each**. An unscoped `type:base` query is a single point of failure, because swu-db returns 502 for the entire query when any one set's base records cannot be served. Per-set queries confine that to the offending set: it is named in a warning, its bases are omitted from the run, and the remaining sets are still written. A set absent from swuapi's set list is never queried, so bases for a set that only swu-db knows about are not picked up until swuapi lists it.
 
 The daily GitHub Actions workflow (`.github/workflows/populate-base-aspects.yml`) keeps the records within the 30-day InfluxDB retention window. The Grafana query joins `events` against `base_aspects` using a derived-table subquery to select only the most recent run's records:
 
@@ -397,6 +399,7 @@ Tests verify behaviour, not implementation. Hook tests cover logic in isolation;
 ### Mocking approach
 
 - External APIs are mocked with `vi.stubGlobal('fetch', ...)` — no real network calls in tests
+- Standalone scripts under `scripts/` instead take an optional `fetchImpl` parameter defaulting to `fetch`, so tests pass a stub directly rather than replacing the global. `populate-base-aspects.mjs` uses this for `fetchSetCodes` and `fetchSwuDbBases`, which lets a test drive per-set success and failure in one call
 - localStorage is mocked with `vi.stubGlobal('localStorage', ...)` to test caching paths
 - All mocks are torn down with `vi.unstubAllGlobals()` in `afterEach`
 - `useUserSettings` is mocked with `vi.mock('../hooks/useUserSettings', ...)` in tests that exercise preference-gated behaviour; `vi.hoisted` is used for mock values that need per-test control

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -156,7 +156,7 @@ Use `--cold` to simulate a first-time user (clears `swu_bases_cache` before each
 - The app is designed for **landscape iPhone** — portrait mode is functional but not the primary target
 - swu-db.com blocks direct browser requests (CORS) — all calls go via the Cloudflare Worker proxy at `https://worker.dmgctrl.app`
 - swuapi.com has CORS enabled and can be called directly from the browser
-- Set codes: `SOR` (Spark of Rebellion), `SHD` (Shadows of the Galaxy), `TWI` (Twilight of the Republic), `JTL` (Jump to Lightspeed), `LOF` (Legends of the Force), `SEC` (Secrets of Power), `LAW` (A Lawless Time), `IBH` (Intro Battle: Hoth)
+- Set codes with bases in the data: `SOR` (Spark of Rebellion), `SHD` (Shadows of the Galaxy), `TWI` (Twilight of the Republic), `JTL` (Jump to Lightspeed), `LOF` (Legends of the Force), `SEC` (Secrets of Power), `LAW` (A Lawless Time), `IBH` (Intro Battle: Hoth), `ASH` (Ashes of the Empire), `TS26` (2026 Twin Suns). No set list is hardcoded in the app: sets flow through from the card APIs, so a new set needs no code change
 - The owner's handle is `yetanotheridentifier` — replace in any URLs
 - Tests use `--legacy-peer-deps` in the GitHub Actions install step
 - `vmin` units are used for game screen sizing to work correctly across orientations

--- a/scripts/populate-base-aspects.mjs
+++ b/scripts/populate-base-aspects.mjs
@@ -1,6 +1,7 @@
 /**
  * Populates the base_aspects InfluxDB measurement with baseKey → aspect mappings.
- * Re-run whenever a new set is released — uses a fixed timestamp so records are overwritten.
+ * Re-run whenever a new set is released. Runs nightly to stay inside InfluxDB's
+ * 30-day retention window.
  *
  * Usage: node scripts/populate-base-aspects.mjs
  * Requires: INFLUXDB_URL, INFLUXDB_TOKEN, INFLUXDB_ORG in environment or local .env.influxdb file
@@ -63,7 +64,7 @@ export function buildBaseAspects(swuApiCards, swuDbCards) {
 
 /**
  * Converts a base→aspect pair to an InfluxDB line protocol record.
- * Uses timestamp=1 (one second past epoch) so re-runs overwrite.
+ * Every record in a run shares one timestamp, so a query can select a whole run.
  */
 export function toLineProtocol(baseKey, aspect, timestampSeconds) {
   const escapedKey = baseKey.replace(/[, =]/g, '\\$&')
@@ -90,11 +91,48 @@ async function fetchSwuApiCards() {
   return allCards
 }
 
-async function fetchSwuDbCards() {
-  const res = await fetch(`${SWU_DB_URL}/cards/search?q=type:base`)
-  if (!res.ok) throw new Error(`swu-db fetch failed: ${res.status}`)
+/**
+ * Lists every set code swuapi knows about, used to scope the swu-db queries.
+ */
+export async function fetchSetCodes(fetchImpl = fetch) {
+  const res = await fetchImpl(`${SWUAPI_URL}/sets`)
+  if (!res.ok) throw new Error(`swuapi sets fetch failed: ${res.status}`)
   const json = await res.json()
-  return json.data.filter(c => c.VariantType === 'Normal')
+  return (json.sets ?? []).map(s => s.code)
+}
+
+/**
+ * Fetches base cards from swu-db one set at a time.
+ *
+ * A single unscoped `type:base` query is a single point of failure: swu-db
+ * returns 502 for the whole query if any one set's base records cannot be
+ * served. Scoping per set confines that to the offending set, which is
+ * reported in `skipped` so the caller can warn rather than lose every set.
+ */
+export async function fetchSwuDbBases(setCodes, fetchImpl = fetch) {
+  const cards = []
+  const skipped = []
+
+  for (const setCode of setCodes) {
+    const url = `${SWU_DB_URL}/cards/search?q=type:base+set:${setCode.toLowerCase()}`
+    let res
+    try {
+      res = await fetchImpl(url)
+    } catch {
+      skipped.push(setCode)
+      continue
+    }
+    if (!res.ok) {
+      skipped.push(setCode)
+      continue
+    }
+    const json = await res.json()
+    for (const card of json.data ?? []) {
+      if (card.VariantType === 'Normal') cards.push(card)
+    }
+  }
+
+  return { cards, skipped }
 }
 
 async function writeToInfluxDB(lines) {
@@ -116,7 +154,23 @@ async function writeToInfluxDB(lines) {
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   console.log('Fetching base data...')
-  const [swuApiCards, swuDbCards] = await Promise.all([fetchSwuApiCards(), fetchSwuDbCards()])
+  const [swuApiCards, setCodes] = await Promise.all([fetchSwuApiCards(), fetchSetCodes()])
+
+  // swu-db is only consulted for sets swuapi has no bases for, so skip the rest.
+  const coveredBySwuApi = new Set(
+    swuApiCards.filter(c => c.variant_type === 'Standard').map(c => c.set_code)
+  )
+  const setsToFetch = setCodes.filter(code => !coveredBySwuApi.has(code))
+
+  console.log(`Fetching ${setsToFetch.length} set(s) from swu-db...`)
+  const { cards: swuDbCards, skipped } = await fetchSwuDbBases(setsToFetch)
+  if (skipped.length > 0) {
+    console.warn(
+      `Warning: swu-db could not serve ${skipped.length} set(s): ${skipped.join(', ')}. ` +
+        'Their bases are omitted from this run; previously written records are unchanged.'
+    )
+  }
+
   const bases = buildBaseAspects(swuApiCards, swuDbCards)
   const runTimestamp = Math.floor(Date.now() / 1000)
   const lines = bases.map(({ baseKey, aspect }) => toLineProtocol(baseKey, aspect, runTimestamp))

--- a/src/test/populateBaseAspects.test.js
+++ b/src/test/populateBaseAspects.test.js
@@ -1,5 +1,23 @@
-import { describe, it, expect } from 'vitest'
-import { buildBaseAspects, toLineProtocol } from '../../scripts/populate-base-aspects.mjs'
+import { describe, it, expect, vi } from 'vitest'
+import {
+  buildBaseAspects,
+  toLineProtocol,
+  fetchSetCodes,
+  fetchSwuDbBases,
+} from '../../scripts/populate-base-aspects.mjs'
+
+// Builds a fetch stub that resolves each URL against a map of responses.
+// A numeric value is treated as a failing status, an array as a card list.
+function stubFetch(routes) {
+  return vi.fn(async url => {
+    const match = Object.keys(routes).find(k => url.includes(k))
+    const value = match === undefined ? 502 : routes[match]
+    if (typeof value === 'number') {
+      return { ok: false, status: value, json: async () => ({}) }
+    }
+    return { ok: true, status: 200, json: async () => value }
+  })
+}
 
 // Minimal swuapi card shape
 function swuApiCard(overrides = {}) {
@@ -79,6 +97,86 @@ describe('buildBaseAspects', () => {
   it('falls back to "None" when swu-db Aspects is empty', () => {
     const result = buildBaseAspects([], [swuDbCard({ Aspects: [] })])
     expect(result[0].aspect).toBe('None')
+  })
+})
+
+describe('fetchSetCodes', () => {
+  it('returns every set code swuapi lists', async () => {
+    const fetchImpl = stubFetch({
+      '/sets': { sets: [{ code: 'SOR' }, { code: 'SHD' }, { code: 'TWI' }] },
+    })
+    await expect(fetchSetCodes(fetchImpl)).resolves.toEqual(['SOR', 'SHD', 'TWI'])
+  })
+
+  it('throws when swuapi cannot serve the set list', async () => {
+    const fetchImpl = stubFetch({ '/sets': 500 })
+    await expect(fetchSetCodes(fetchImpl)).rejects.toThrow('swuapi sets fetch failed: 500')
+  })
+})
+
+describe('fetchSwuDbBases', () => {
+  const sorCard = swuDbCard()
+  const shdCard = swuDbCard({ Set: 'SHD', Number: '021', Aspects: ['Command'] })
+
+  it('issues one scoped request per set code', async () => {
+    const fetchImpl = stubFetch({
+      'set:sor': { data: [sorCard] },
+      'set:shd': { data: [shdCard] },
+    })
+    await fetchSwuDbBases(['SOR', 'SHD'], fetchImpl)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    const urls = fetchImpl.mock.calls.map(c => c[0])
+    expect(urls[0]).toContain('type:base+set:sor')
+    expect(urls[1]).toContain('type:base+set:shd')
+  })
+
+  it('collects cards from every set that responds', async () => {
+    const fetchImpl = stubFetch({
+      'set:sor': { data: [sorCard] },
+      'set:shd': { data: [shdCard] },
+    })
+    const { cards, skipped } = await fetchSwuDbBases(['SOR', 'SHD'], fetchImpl)
+
+    expect(cards).toEqual([sorCard, shdCard])
+    expect(skipped).toEqual([])
+  })
+
+  // The HMW regression: one set 502s while the rest are healthy.
+  it('skips a set the API cannot serve and keeps the others', async () => {
+    const fetchImpl = stubFetch({
+      'set:sor': { data: [sorCard] },
+      'set:hmw': 502,
+      'set:shd': { data: [shdCard] },
+    })
+    const { cards, skipped } = await fetchSwuDbBases(['SOR', 'HMW', 'SHD'], fetchImpl)
+
+    expect(cards).toEqual([sorCard, shdCard])
+    expect(skipped).toEqual(['HMW'])
+  })
+
+  it('does not throw when every set fails', async () => {
+    const fetchImpl = stubFetch({ 'set:sor': 502, 'set:shd': 502 })
+    const { cards, skipped } = await fetchSwuDbBases(['SOR', 'SHD'], fetchImpl)
+
+    expect(cards).toEqual([])
+    expect(skipped).toEqual(['SOR', 'SHD'])
+  })
+
+  it('excludes non-Normal variants', async () => {
+    const foil = swuDbCard({ Number: '020', VariantType: 'Foil' })
+    const fetchImpl = stubFetch({ 'set:sor': { data: [sorCard, foil] } })
+    const { cards } = await fetchSwuDbBases(['SOR'], fetchImpl)
+
+    expect(cards).toEqual([sorCard])
+  })
+
+  it('treats a set with no data array as empty rather than failing', async () => {
+    const fetchImpl = stubFetch({ 'set:sor': {} })
+    const { cards, skipped } = await fetchSwuDbBases(['SOR'], fetchImpl)
+
+    expect(cards).toEqual([])
+    expect(skipped).toEqual([])
   })
 })
 


### PR DESCRIPTION
## bug/populate-base-job: scope swu-db base queries per set

Closes #535.

### What changed and why

The nightly `populate-base-aspects` job failed on 29, 30 and 31 August. The script fetched
every base in one unscoped call, `GET api.swu-db.com/cards/search?q=type:base`, and swu-db
now returns 502 for that query because of a new set, HMW (Homeworlds), whose base records it
cannot serve. One unserveable set therefore took down the whole run.

`fetchSwuDbBases` now queries swu-db one set at a time. The set list comes from swuapi's
`/sets`, restricted to the sets swuapi has no bases for, which is the only reason swu-db is
consulted at all. A set that fails is named in a warning and skipped; every other set is still
written. This removes the single point of failure rather than special-casing HMW, so the next
set that breaks upstream costs one warning instead of the night's run.

`fetchSetCodes` and `fetchSwuDbBases` are exported and take an optional `fetchImpl`, which is
what makes the fetch layer testable. It was previously unexported and untested, and that gap
is why this reached production.

### Evidence

Measured against the live APIs:

- Full pipeline: 89 bases, 0 sets skipped, no duplicate keys. This matches what the old code
  produced before HMW appeared (57 from swuapi, plus 32 from swu-db for SOR, SHD and TWI).
- Fault path against the real 502: `fetchSwuDbBases(['SOR','HMW','SHD'])` returns SOR 12 and
  SHD 8, with `skipped: ['HMW']`, and does not throw.
- Failure is specific to HMW bases, not a swu-db outage: `type:base -set:hmw` returns 200 with
  91 bases, all 28 other sets return 200 when queried individually, and HMW's units, leaders,
  events and upgrades are served normally.

8 new unit tests cover the per-set fetch, including the skip-one-set-keep-the-rest case.
Root suite 1724 passed, proxy 27, sealed 1990 (+1 expected fail). `tsc -b` clean. eslint clean
on both changed files.

### Not done

- HMW base aspects are still missing, and no change here can recover them. swuapi returns zero
  HMW cards and does not list the set; swu-db has the set but 502s on its bases. This needs a
  bug report to swu-db. The job goes green and every other set stays current in the meantime.
- Because the set list comes from swuapi, a set only swu-db knows about is never queried. That
  is what keeps HMW out of the loop today, and it also means such a set would not be picked up
  automatically. Noted in `architecture-process.md`.
- No retry or backoff: the 502 is deterministic, not transient, so retries would not help.
- Two pre-existing lint errors in `src/hooks/useInstallPrompt.ts`, plus warnings in
  `imagePreview.tsx` and `swuTournamentScreenView.tsx`, are unrelated and left alone. They are
  present on a clean tree.

### Docs

- `architecture-process.md`: per-set fetch strategy and its failure behaviour; the `fetchImpl`
  injection pattern added to the mocking section.
- `architecture-implementation.md`: updated script description and exports.
- `project-overview.md`: set-code list was already missing `ASH` and `TS26`; added, with a note
  that no set list is hardcoded, so a new set needs no code change.

Two stale claims corrected in passing: the script and `architecture-process.md` both said a
fixed timestamp made re-runs overwrite. Records are written at the run's timestamp, and the
Grafana query selects the latest run.

### Manual check for the reviewer

The script was not run end to end, because a local `.env.influxdb` is present and it would have
written to production InfluxDB. The real check is a `workflow_dispatch` on
`.github/workflows/populate-base-aspects.yml`, whenever you are happy for it to write. Expect
89 bases and no skipped sets.